### PR TITLE
Update state slice when selector changes

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/esm/index.js": {
-    "bundled": 2379,
-    "minified": 885,
-    "gzipped": 470,
+    "bundled": 2443,
+    "minified": 929,
+    "gzipped": 491,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,8 +14,8 @@
     }
   },
   "dist/cjs/index.js": {
-    "bundled": 2751,
-    "minified": 1089,
-    "gzipped": 527
+    "bundled": 2843,
+    "minified": 1148,
+    "gzipped": 550
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/esm/index.js": {
-    "bundled": 2443,
-    "minified": 929,
-    "gzipped": 491,
+    "bundled": 2756,
+    "minified": 989,
+    "gzipped": 509,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,8 +14,8 @@
     }
   },
   "dist/cjs/index.js": {
-    "bundled": 2843,
-    "minified": 1148,
-    "gzipped": 550
+    "bundled": 3079,
+    "minified": 1126,
+    "gzipped": 527
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/esm/index.js": {
-    "bundled": 2417,
-    "minified": 898,
-    "gzipped": 470,
+    "bundled": 2430,
+    "minified": 912,
+    "gzipped": 479,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,8 +14,8 @@
     }
   },
   "dist/cjs/index.js": {
-    "bundled": 2888,
-    "minified": 1140,
-    "gzipped": 540
+    "bundled": 2800,
+    "minified": 1114,
+    "gzipped": 537
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/esm/index.js": {
-    "bundled": 2430,
-    "minified": 912,
-    "gzipped": 479,
+    "bundled": 2379,
+    "minified": 885,
+    "gzipped": 470,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,8 +14,8 @@
     }
   },
   "dist/cjs/index.js": {
-    "bundled": 2800,
-    "minified": 1114,
-    "gzipped": 537
+    "bundled": 2751,
+    "minified": 1089,
+    "gzipped": 527
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,9 @@ export default function create<
   function useStore<U>(selector?: StateSelector<State, U>) {
     // Gets entire state if no selector was passed in
     const selectState = typeof selector === 'function' ? selector : getState
-    // Not storing state in react hooks, just using to enable forcing an update
+    // Nothing stored in useState, just using to enable forcing an update
     const [, forceUpdate] = React.useState({})
+    // Always get latest slice because selector can change
     const stateSlice = selectState(state)
     // Prevent subscribing/unsubscribing to the store when values change by storing them in a ref object
     const refs = React.useRef({ stateSlice, selectState }).current
@@ -55,13 +56,9 @@ export default function create<
     // Subscribe/unsubscribe to the store only on mount/unmount
     React.useEffect(() => {
       return subscribe(() => {
-        // Get fresh selected state
-        const selected = refs.selectState(state)
-        if (!shallowEqual(refs.stateSlice, selected)) {
-          // Refresh local slice
-          refs.stateSlice = selected
+        // Update component if latest state slice doesn't match
+        if (!shallowEqual(refs.stateSlice, refs.selectState(state)))
           forceUpdate({})
-        }
       })
     }, [])
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,14 +36,23 @@ export default function create<
   }
 
   function useStore(): State
-  function useStore<U>(selector: StateSelector<State, U>): U
-  function useStore<U>(selector?: StateSelector<State, U>) {
+  function useStore<U>(
+    selector: StateSelector<State, U>,
+    deps?: readonly any[]
+  ): U
+  function useStore<U>(
+    selector?: StateSelector<State, U>,
+    deps?: readonly any[]
+  ) {
     // Gets entire state if no selector was passed in
-    const selectState = typeof selector === 'function' ? selector : getState
+    const selectState = React.useCallback(
+      typeof selector === 'function' ? selector : getState,
+      deps as readonly any[]
+    )
     // Nothing stored in useState, just using to enable forcing an update
     const [, forceUpdate] = React.useState({})
-    // Always get latest slice because selector can change
-    const stateSlice = selectState(state)
+    // Always get latest slice unless dependencies are passed in
+    const stateSlice = React.useMemo(() => selectState(state), deps)
     // Prevent subscribing/unsubscribing to the store when values change by storing them in a ref object
     const refs = React.useRef({ stateSlice, selectState }).current
 

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -160,3 +160,24 @@ it('can update the selector even when the store does not change', async () => {
   rerender(<Component selector={s => s.two} />)
   await waitForElement(() => getByText('two'))
 })
+
+it('can pass optional dependencies to restrict selector calls', async () => {
+  const [useStore] = create(() => ({}))
+  let selectorCallCount = 0
+
+  function Component({ deps }) {
+    useStore(() => {
+      selectorCallCount++
+    }, deps)
+    return <div>{selectorCallCount}</div>
+  }
+
+  const { rerender } = render(<Component deps={[true]} />)
+  expect(selectorCallCount).toBe(1)
+
+  rerender(<Component deps={[true]} />)
+  expect(selectorCallCount).toBe(1)
+
+  rerender(<Component deps={[false]} />)
+  expect(selectorCallCount).toBe(2)
+})

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import {
   cleanup,
   fireEvent,
@@ -38,7 +38,7 @@ it('updates the store', () => {
     renderCount++
     const { count, dec } = useStore()
 
-    useEffect(dec, [])
+    React.useEffect(dec, [])
 
     if (renderCount === 1) {
       expect(count).toBe(1)
@@ -142,4 +142,21 @@ it('can destroy the store', () => {
   // should this throw?
   setState({ value: 2 })
   expect(getState().value).toEqual(2)
+})
+
+it('can update the selector even when the store does not change', async () => {
+  const [useStore] = create(() => ({
+    one: 'one',
+    two: 'two',
+  }))
+
+  function Component({ selector }) {
+    return <div>{useStore(selector)}</div>
+  }
+
+  const { getByText, rerender } = render(<Component selector={s => s.one} />)
+  await waitForElement(() => getByText('one'))
+
+  rerender(<Component selector={s => s.two} />)
+  await waitForElement(() => getByText('two'))
 })


### PR DESCRIPTION
The latest selector was only used in the subscribe callback. It should also be used when `useStore` is called. Should fix #18.

This change should be reviewed and tested by others (@drcmda, @timkindberg) to make sure it actually fixes the issue and does not cause regressions. I only added one test.