### PR TITLE
Add selector to api.subscribe

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/esm/index.js": {
-    "bundled": 2627,
-    "minified": 963,
-    "gzipped": 506,
+    "bundled": 3293,
+    "minified": 1084,
+    "gzipped": 566,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,8 +14,8 @@
     }
   },
   "dist/cjs/index.js": {
-    "bundled": 2875,
-    "minified": 1082,
-    "gzipped": 528
+    "bundled": 3698,
+    "minified": 1230,
+    "gzipped": 590
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/esm/index.js": {
-    "bundled": 3293,
-    "minified": 1084,
-    "gzipped": 566,
+    "bundled": 3092,
+    "minified": 1031,
+    "gzipped": 538,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,8 +14,8 @@
     }
   },
   "dist/cjs/index.js": {
-    "bundled": 3698,
-    "minified": 1230,
-    "gzipped": 590
+    "bundled": 3425,
+    "minified": 1149,
+    "gzipped": 556
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -196,14 +196,16 @@ You can use it with or without React out of the box.
 const [, api] = create({ n: 0 })
 
 // Getting fresh state
-const n = api.getState().n
+const num = api.getState().n
 // Listening to changes
 const unsub = api.subscribe(state => console.log(state.n))
+// And with a selector
+const unsub2 = api.subscribe(state => state.n, n => console.log(n))
 // Updating state, will trigger listeners
 api.setState({ n: 1 })
-// Unsubscribing handler
+// Unsubscribing listener
 unsub()
-// Destroying the store
+// Destroying the store (removing all listeners)
 api.destroy()
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,27 @@
-import { useCallback, useLayoutEffect, useReducer, useRef } from 'react'
+import { useLayoutEffect, useReducer, useRef } from 'react'
 import shallowEqual from './shallowEqual'
 
-export type StateListener<T> = (state: T) => void
-export type StateSelector<T, U> = (state: T) => U
-export type PartialState<T> = Partial<T> | ((state: T) => Partial<T>)
-
 export type State = Record<string, any>
-export type SetState<T> = (partialState: PartialState<T>) => void
-export type GetState<T> = () => T
+export type StateListener<T extends State, U = T> = (state: U) => void
+export type StateSelector<T extends State, U> = (state: T) => U
+export type PartialState<T extends State> =
+  | Partial<T>
+  | ((state: T) => Partial<T>)
+export type SetState<T extends State> = (partial: PartialState<T>) => void
+export type GetState<T extends State> = () => T
 
-export type UseStore<T> = {
+export interface Subscribe<T> {
+  (listener: StateListener<T>): () => void
+  <U>(selector: StateSelector<T, U>, listener: StateListener<T, U>): () => void
+}
+export interface UseStore<T> {
   (): T
   <U>(selector: StateSelector<T, U>, dependencies?: ReadonlyArray<any>): U
 }
-
 export interface StoreApi<T> {
   getState: GetState<T>
   setState: SetState<T>
-  subscribe: (listener: StateListener<T>) => () => void
+  subscribe: Subscribe<T>
   destroy: () => void
 }
 
@@ -28,78 +32,98 @@ export default function create<TState extends State>(
 ): [UseStore<TState>, StoreApi<TState>] {
   const listeners: Set<StateListener<TState>> = new Set()
 
-  const setState = (partialState: PartialState<TState>) => {
-    state = Object.assign(
-      {},
-      state,
-      typeof partialState === 'function' ? partialState(state) : partialState
-    )
-    listeners.forEach(listener => listener(state))
-  }
-
-  const getState = () => state
-
-  const subscribe = (listener: StateListener<TState>) => {
-    listeners.add(listener)
-    return () => {
-      listeners.delete(listener)
+  const setState: SetState<TState> = partial => {
+    const partialState =
+      typeof partial === 'function' ? partial(state) : partial
+    // Shallow equality check only on the values in partialState
+    // This is (hopefully) a performance optimization
+    if (
+      partialState !== state &&
+      Object.entries(partialState).some(
+        ([key, value]) => !Object.is(state[key], value)
+      )
+    ) {
+      state = Object.assign({}, state, partialState)
+      listeners.forEach(listener => listener(state))
     }
   }
 
-  const destroy = () => {
-    listeners.clear()
-    state = {} as TState
+  const getState: GetState<TState> = () => state
+
+  // Optional selector param goes first so we can infer its return type and use
+  // it for listener
+  const subscribe: Subscribe<TState> = <TStateSlice>(
+    selectorOrListener:
+      | StateListener<TState>
+      | StateSelector<TState, TStateSlice>,
+    listenerOrUndef?: StateListener<TState, TStateSlice>
+  ) => {
+    let listener = selectorOrListener
+    // Existance of second param means a selector was passed in
+    if (listenerOrUndef) {
+      // We know selector is not type StateListener so it must be StateSelector
+      const selector = selectorOrListener as StateSelector<TState, TStateSlice>
+      let stateSlice = selector(state)
+      listener = () => {
+        const selectedSlice = selector(state)
+        if (!shallowEqual(stateSlice, (stateSlice = selectedSlice)))
+          listenerOrUndef(stateSlice)
+      }
+    }
+    listeners.add(listener)
+    return () => void listeners.delete(listener)
   }
 
-  function useStore(): TState
-  function useStore<U>(
-    selector: StateSelector<TState, U>,
+  const destroy: StoreApi<TState>['destroy'] = () => {
+    listeners.clear()
+  }
+
+  const useStore: UseStore<TState> = <TStateSlice>(
+    selector?: StateSelector<TState, TStateSlice>,
     dependencies?: ReadonlyArray<any>
-  ): U
-  function useStore<U>(
-    selector?: StateSelector<TState, U>,
-    dependencies?: ReadonlyArray<any>
-  ): TState | U {
-    // State selector gets entire state if no selector was passed in
-    const stateSelector = typeof selector === 'function' ? selector : getState
-    const selectState = useCallback(
-      stateSelector,
-      dependencies as ReadonlyArray<any>
+  ): TState | TStateSlice => {
+    const selectorRef = useRef(selector)
+    const depsRef = useRef(dependencies)
+    let [stateSlice, dispatch] = useReducer(
+      reducer,
+      state,
+      // Optional third argument but required to not be 'undefined'
+      selector as StateSelector<TState, TStateSlice>
     )
-    const selectStateRef = useRef(selectState)
-    let [stateSlice, dispatch] = useReducer(reducer, state, selectState)
 
-    // Call new selector if it has changed
-    if (selectState !== selectStateRef.current) stateSlice = selectState(state)
+    // Need to manually get state slice if selector has changed with no deps or
+    // deps exist and have changed
+    if (
+      selector &&
+      ((!dependencies && selector !== selectorRef.current) ||
+        (dependencies && !shallowEqual(dependencies, depsRef.current)))
+    ) {
+      stateSlice = selector(state)
+    }
 
-    // Store in ref to enable updating without rerunning subscribe/unsubscribe
-    const stateSliceRef = useRef(stateSlice)
-
-    // Update refs only after view has been updated
+    // Update refs synchronously after view has been updated
     useLayoutEffect(() => {
-      selectStateRef.current = selectState
-      stateSliceRef.current = stateSlice
-    }, [selectState, stateSlice])
+      selectorRef.current = selector
+      depsRef.current = dependencies
+    }, dependencies || [selector])
 
-    // Subscribe/unsubscribe to the store only on mount/unmount
     useLayoutEffect(() => {
-      return subscribe(() => {
-        // Use the last selector passed to useStore to get current state slice
-        const selectedSlice = selectStateRef.current(state)
-        // Shallow compare previous state slice with current and rerender only if changed
-        if (!shallowEqual(stateSliceRef.current, selectedSlice))
-          dispatch(selectedSlice)
-      })
-    }, [])
+      return selector
+        ? subscribe(
+            // Truthy check because it might be possible to set selectorRef to
+            // undefined and call this subscriber before it resubscribes
+            () => (selectorRef.current ? selectorRef.current(state) : state),
+            dispatch
+          )
+        : subscribe(dispatch)
+      // Only resubscribe to the store when changing selector from function to
+      // undefined or undefined to function
+    }, [!selector])
 
     return stateSlice
   }
 
-  let state = createState(
-    setState as SetState<State>,
-    getState as GetState<State>
-  )
-  const api = { destroy, getState, setState, subscribe }
+  let state = createState(setState as SetState<State>, getState)
 
-  return [useStore, api]
+  return [useStore, { destroy, getState, setState, subscribe }]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,14 +35,7 @@ export default function create<TState extends State>(
   const setState: SetState<TState> = partial => {
     const partialState =
       typeof partial === 'function' ? partial(state) : partial
-    // Shallow equality check only on the values in partialState
-    // This is (hopefully) a performance optimization
-    if (
-      partialState !== state &&
-      Object.entries(partialState).some(
-        ([key, value]) => !Object.is(state[key], value)
-      )
-    ) {
+    if (partialState !== state) {
       state = Object.assign({}, state, partialState)
       listeners.forEach(listener => listener(state))
     }

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -6,7 +6,17 @@ import {
   render,
   waitForElement,
 } from 'react-testing-library'
-import create from '../src/index'
+import create, {
+  GetState,
+  PartialState,
+  SetState,
+  State,
+  StateListener,
+  StateSelector,
+  StoreApi,
+  Subscribe,
+  UseStore,
+} from '../src/index'
 
 afterEach(cleanup)
 
@@ -104,7 +114,7 @@ it('can set the store', () => {
 })
 
 it('can subscribe to the store', () => {
-  expect.assertions(2)
+  expect.assertions(3)
 
   const [, { setState, subscribe }] = create(() => ({ value: 1 }))
 
@@ -116,7 +126,15 @@ it('can subscribe to the store', () => {
     expect(newState.value).toBe(2)
     unsub2()
   })
+  const unsub3 = subscribe(
+    state => state.value,
+    newValue => {
+      expect(newValue).toBe(2)
+      unsub3()
+    }
+  )
 
+  setState({ value: 1 })
   setState({ value: 2 })
 })
 
@@ -164,13 +182,13 @@ it('can pass optional dependencies to restrict selector calls', () => {
   }
 
   const { rerender } = render(<Component deps={[true]} />)
-  expect(selectorCallCount).toBe(1)
+  expect(selectorCallCount).toBe(2)
 
   rerender(<Component deps={[true]} />)
-  expect(selectorCallCount).toBe(1)
+  expect(selectorCallCount).toBe(2)
 
   rerender(<Component deps={[false]} />)
-  expect(selectorCallCount).toBe(2)
+  expect(selectorCallCount).toBe(3)
 })
 
 it('can update state without updating dependencies', async () => {
@@ -188,4 +206,59 @@ it('can update state without updating dependencies', async () => {
     setState({ value: 1 })
   })
   await waitForElement(() => getByText('value: 1'))
+})
+
+it('can use exposed types', () => {
+  interface ExampleState extends State {
+    num: number
+    numGet: () => number
+    numGetState: () => number
+    numSet: (v: number) => void
+    numSetState: (v: number) => void
+  }
+
+  const listener: StateListener<ExampleState> = state => {
+    const value = state.num * state.numGet() * state.numGetState()
+    state.numSet(value)
+    state.numSetState(value)
+  }
+  const selector: StateSelector<ExampleState, number> = state => state.num
+  const partial: PartialState<ExampleState> = { num: 2, numGet: () => 2 }
+  const partialFn: PartialState<ExampleState> = state => ({ num: 2, ...state })
+
+  const [useStore, storeApi] = create(
+    (set: SetState<ExampleState>, get: GetState<ExampleState>) => ({
+      num: 1,
+      numGet: () => get().num,
+      numGetState: () => storeApi.getState().num,
+      numSet: (v: number) => set({ num: v }),
+      numSetState: (v: number) => storeApi.setState({ num: v }),
+    })
+  )
+
+  function checkAllTypes(
+    getState: GetState<ExampleState>,
+    partialState: PartialState<ExampleState>,
+    setState: SetState<ExampleState>,
+    state: State,
+    stateListener: StateListener<ExampleState>,
+    stateSelector: StateSelector<ExampleState, number>,
+    storeApi: StoreApi<ExampleState>,
+    subscribe: Subscribe<ExampleState>,
+    useStore: UseStore<ExampleState>
+  ) {
+    expect(true).toBeTruthy()
+  }
+
+  checkAllTypes(
+    storeApi.getState,
+    Math.random() > 0.5 ? partial : partialFn,
+    storeApi.setState,
+    storeApi.getState(),
+    listener,
+    selector,
+    storeApi,
+    storeApi.subscribe,
+    useStore
+  )
 })


### PR DESCRIPTION
Fixes #24 and adds feature #23.

This was a bit more painful than I thought it would be. Expected changes were made to `setState` and `subscribe`. Unexpected changes were made to `useStore`. For performance reasons, I decided to not use `getState` as a default selector if none is passed in. If I didn't do this, a `shallowEqual` check would be performed on the entire store for components that use `useStore` without a selector. This led to a cascade of required changes that should be tested more thoroughly.

Additionally, I removed the `state = {}` in `destroy` due to the fact that it invisibly breaks the store when using TypeScript (Type is still `TState` but value is `{}`). External references to the store or objects in the store still won't be garbage collected if they can be reached so I'm not sure if setting the store to an empty object helps much but please correct me if I'm wrong.

Documentation also needs to be added. Just a reminder, the selector argument goes first:
```js
api.subscribe(state => state.foo, foo => console.log(foo))
```