### PR TITLE
Use the state generic in SetState and GetState types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export interface StoreApi<T> {
 const reducer = <T>(state: any, newState: T) => newState
 
 export default function create<TState extends State>(
-  createState: (set: SetState<State>, get: GetState<State>) => TState
+  createState: (set: SetState<TState>, get: GetState<TState>) => TState
 ): [UseStore<TState>, StoreApi<TState>] {
   const listeners: Set<StateListener<TState>> = new Set()
 


### PR DESCRIPTION
After upgrading to `0.2.0`, I've noticed a few type issues on our end.
It seems like we needed to use the generic in `SetState` and `GetState`.