### PR TITLE
Fix SetState & GetState Typescript declaration in create function arg…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,11 @@ export interface StoreApi<T> {
 const reducer = <T>(state: any, newState: T) => newState
 
 export default function create<TState extends State>(
-  createState: (set: SetState<State>, get: GetState<State>, api: any) => TState
+  createState: (
+    set: SetState<TState>,
+    get: GetState<TState>,
+    api: any
+  ) => TState
 ): [UseStore<TState>, StoreApi<TState>] {
   const listeners: Set<StateListener<TState>> = new Set()
 


### PR DESCRIPTION
The `create` function typescript definition has a generic parameter that helps to define the final state that will be used : `TState extends State`. This state has to extend `State` (`Record<string, any>`) which is relevant for  a state.

Unfortunately both `set` and `get` parameters types don't use this generic parameter and instead are bound to `State` as we can see :
```  createState: (set: SetState<State>, get: GetState<State>, api: any) => TState```

It is not very anoying for the `set` parameter, but it is really a pity that when one uses the `get` method, the definition does not simply type the return to `TState` instead of the very neutral `State`.

Is it just a mistake ? Or is there a reason not to have used `TState` in `set: SetState<State>` and `get: GetState<State>` ? (I must admit that I would expect `set: SetState<TState>` and `get: GetState<TState>` instead).