### PR TITLE
Replace useLayoutEffect to useEffect in server side to fix ssr issue

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/esm/index.js": {
-    "bundled": 3159,
-    "minified": 1031,
-    "gzipped": 538,
+    "bundled": 3181,
+    "minified": 1037,
+    "gzipped": 542,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,8 +14,8 @@
     }
   },
   "dist/cjs/index.js": {
-    "bundled": 3492,
-    "minified": 1149,
-    "gzipped": 556
+    "bundled": 3514,
+    "minified": 1155,
+    "gzipped": 561
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
-import { useLayoutEffect, useReducer, useRef } from 'react'
+import { useEffect, useLayoutEffect, useReducer, useRef } from 'react'
 import shallowEqual from './shallowEqual'
+
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
 export type State = Record<string, any>
 export type StateListener<T extends State, U = T> = (state: U) => void
@@ -95,12 +98,12 @@ export default function create<TState extends State>(
     }
 
     // Update refs synchronously after view has been updated
-    useLayoutEffect(() => {
+    useIsomorphicLayoutEffect(() => {
       selectorRef.current = selector
       depsRef.current = dependencies
     }, dependencies || [selector])
 
-    useLayoutEffect(() => {
+    useIsomorphicLayoutEffect(() => {
       return selector
         ? subscribe(
             // Truthy check because it might be possible to set selectorRef to


### PR DESCRIPTION
Replace useLayoutEffect to useEffect in server side not to print below error message.

```
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://fb.me/react-uselayouteffect-ssr for common fixes.

```

https://github.com/react-spring/zustand/issues/11