### PR TITLE
try/catch selectors in order to prevent zombie children

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,13 @@ export default function create<TState extends State>(
         ? subscribe(
             // Truthy check because it might be possible to set selectorRef to
             // undefined and call this subscriber before it resubscribes
-            () => (selectorRef.current ? selectorRef.current(state) : state),
+            () => {
+              try {
+                // See: https://react-redux.js.org/next/api/hooks#stale-props-and-zombie-children
+                // And reduxes reference impl: https://github.com/reduxjs/react-redux/blob/master/src/hooks/useSelector.js
+                return selectorRef.current ? selectorRef.current(state) : state
+              } catch (e) {}
+            },
             dispatch
           )
         : subscribe(dispatch)


### PR DESCRIPTION
See: https://react-redux.js.org/next/api/hooks#stale-props-and-zombie-children
And reduxes reference impl: https://github.com/reduxjs/react-redux/blob/master/src/hooks/useSelector.js#L84-L103

Without this, taking away state on which certain selector could rely on forces them to always check for the existence of state, independently of the component structure. 

This is b/c state reconciling with hooks falls out of sync with component reconciling (where each component is executed in order).

I don't know about the performance impact of this. Though seeing that redux has merged this, it seems to me they must've profiled and accepted it for what it is.