### PR TITLE
1.x (optional equalityFn, error safe selectors, middleware: redux & devtools)

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -19,9 +19,9 @@
     "gzipped": 597
   },
   "dist/index.js": {
-    "bundled": 4688,
-    "minified": 1774,
-    "gzipped": 898,
+    "bundled": 3333,
+    "minified": 1107,
+    "gzipped": 579,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -33,9 +33,9 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 5744,
-    "minified": 2301,
-    "gzipped": 1039
+    "bundled": 3754,
+    "minified": 1277,
+    "gzipped": 624
   },
   "dist/middleware.js": {
     "bundled": 1365,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -19,9 +19,9 @@
     "gzipped": 597
   },
   "dist/index.js": {
-    "bundled": 3308,
-    "minified": 1146,
-    "gzipped": 584,
+    "bundled": 4688,
+    "minified": 1774,
+    "gzipped": 898,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -33,14 +33,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 3628,
-    "minified": 1254,
-    "gzipped": 597
+    "bundled": 5744,
+    "minified": 2301,
+    "gzipped": 1039
   },
   "dist/middleware.js": {
-    "bundled": 1327,
-    "minified": 664,
-    "gzipped": 391,
+    "bundled": 1365,
+    "minified": 681,
+    "gzipped": 402,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -52,8 +52,8 @@
     }
   },
   "dist/middleware.cjs.js": {
-    "bundled": 2014,
-    "minified": 1076,
-    "gzipped": 567
+    "bundled": 2068,
+    "minified": 1096,
+    "gzipped": 579
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,21 +1,23 @@
 {
   "name": "zustand",
+  "private": true,
   "version": "1.0.0",
   "description": "🐻 Bear necessities for state management in React",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "index.cjs.js",
+  "module": "index.js",
+  "types": "index.d.ts",
   "files": [
-    "dist/**"
+    "**"
   ],
   "sideEffects": false,
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "rollup -c",
+    "build": "rollup -c && npm run copy",
     "prepare": "npm run build --scripts-prepend-node-path",
     "test": "jest",
     "test:dev": "jest --watch --no-coverage",
-    "test:coverage:watch": "jest --watch"
+    "test:coverage:watch": "jest --watch",
+    "copy": "copyfiles -f package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\""
   },
   "husky": {
     "hooks": {
@@ -83,8 +85,10 @@
     "@testing-library/react": "^8.0.1",
     "@types/jest": "^24.0.15",
     "@types/react": "^16.8.22",
+    "copyfiles": "^2.1.0",
     "husky": "^2.4.1",
     "jest": "^24.8.0",
+    "json": "^9.0.6",
     "lint-staged": "^8.2.1",
     "prettier": "^1.18.2",
     "react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zustand",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "description": "🐻 Bear necessities for state management in React",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zustand",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.0-beta.0",
   "description": "🐻 Bear necessities for state management in React",
   "main": "index.cjs.js",
   "module": "index.js",

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ const person = usePersonStore(state => state.persons[currentUser])
 
 ## Memoizing selectors
 
-Selectors run on state changes, as well as when the component renders. If you give zustand a fixed reference, it will only run on state changes, or when the selector changes. Don't worry about this, unless your selector is expensive.
+Selectors run on state changes, as well as when the component renders. If you give zustand a fixed reference it will only run on state changes, or when the selector changes. Don't worry about this, unless your selector is expensive.
 
 ```js
 const fooSelector = useCallback(state => state.foo[props.id], [props.id])

--- a/readme.md
+++ b/readme.md
@@ -62,17 +62,19 @@ const state = useStore()
 
 ## Selecting multiple state slices
 
-Just like with Redux's mapStateToProps, useStore can select state, either atomically or by returning an object. It will run a small shallow-equal test over the results you return and update the component on changes only.
-
-```jsx
-const { foo, bar } = useStore(state => ({ foo: state.foo, bar: state.bar }))
-```
-
-Atomic selects do the same ...
+zustand defaults to strict-quality (old === new) to detect changes, this very efficient for atomic state picks. 
 
 ```jsx
 const foo = useStore(state => state.foo)
 const bar = useStore(state => state.bar)
+```
+
+If you want to construct a single object with multiple state-picks inside, similar to Redux's mapStateToProps, you can tell zustand that you want the object to be diffed shallowly.
+
+```jsx
+import { shallowEqual } from 'zustand'
+
+const { foo, bar } = useStore(state => ({ foo: state.foo, bar: state.bar }), shallowEqual)
 ```
 
 ## Fetching from multiple stores
@@ -84,30 +86,14 @@ const currentUser = useCredentialsStore(state => state.currentUser)
 const person = usePersonStore(state => state.persons[currentUser])
 ```
 
-## Memoizing selectors, optimizing performance
+## Memoizing selectors
 
-Say you select a piece of state ...
-
-```js
-const foo = useStore(state => state.foo[props.id])
-```
-
-Your selector (`state => state.foo[props.id]`) will run on every state change, as well as every time the component renders. It isn't that expensive in this case, but let's optimize it for arguments sake.
-
-You can either pass a static reference:
+Selectors run on state changes, as well as when the component renders. If you give zustand a fixed reference, it will only run on state changes, or when the selector changes. Don't worry about this, unless your selector is expensive.
 
 ```js
 const fooSelector = useCallback(state => state.foo[props.id], [props.id])
 const foo = useStore(fooSelector)
 ```
-
-Or an optional dependencies array to let zustand know when the selector needs to update:
-
-```js
-const foo = useStore(state => state.foo[props.id], [props.id])
-```
-
-From now on your selector is memoized and will only run when either the state changes, or the selector itself.
 
 ## Async actions
 

--- a/readme.md
+++ b/readme.md
@@ -62,14 +62,14 @@ const state = useStore()
 
 ## Selecting multiple state slices
 
-zustand defaults to strict-quality (old === new) to detect changes, this very efficient for atomic state picks. 
+zustand defaults to strict-equality (old === new) to detect changes, this is efficient for atomic state picks. 
 
 ```jsx
 const foo = useStore(state => state.foo)
 const bar = useStore(state => state.bar)
 ```
 
-If you want to construct a single object with multiple state-picks inside, similar to Redux's mapStateToProps, you can tell zustand that you want the object to be diffed shallowly.
+If you want to construct a single object with multiple state-picks inside, similar to redux's mapStateToProps, you can tell zustand that you want the object to be diffed shallowly.
 
 ```jsx
 import { shallowEqual } from 'zustand'

--- a/readme.md
+++ b/readme.md
@@ -134,27 +134,6 @@ const set = useStore(state => state.set)
 set(state => void state.nested.structure.contains = null)
 ```
 
-## Can't live without redux-like reducers and action types?
-
-```jsx
-const types = { increase: "INCREASE", decrease: "DECREASE" }
-
-const reducer = (state, { type, by = 1 }) => {
-  switch (type) {
-    case types.increase: return { count: state.count + by }
-    case types.decrease: return { count: state.count - by }
-  }
-}
-
-const [useStore] = create(set => ({
-  count: 0,
-  dispatch: args => set(state => reducer(state, args)),
-}))
-
-const dispatch = useStore(state => state.dispatch)
-dispatch({ type: types.increase, by: 2 })
-```
-
 ## Reading/writing state and reacting to changes outside of components
 
 You can use it with or without React out of the box.
@@ -214,6 +193,42 @@ const [useStore] = create(log(immer(set => ({
 }))))
 ```
 
+## Can't live without redux-like reducers and action types?
+
+```jsx
+const types = { increase: "INCREASE", decrease: "DECREASE" }
+
+const reducer = (state, { type, by = 1 }) => {
+  switch (type) {
+    case types.increase: return { count: state.count + by }
+    case types.decrease: return { count: state.count - by }
+  }
+}
+
+const [useStore] = create(set => ({
+  count: 0,
+  dispatch: args => set(state => reducer(state, args)),
+}))
+
+const dispatch = useStore(state => state.dispatch)
+dispatch({ type: types.increase, by: 2 })
+```
+
+Or, just use our redux-middleware. It wires up your main-reducer, sets initial state, and adds a dispatch function to the state itself and the vanilla api. Try [this](https://codesandbox.io/s/amazing-kepler-swxol) example.
+
+```jsx
+import { redux } from 'zustand'
+
+const [useStore] = create(redux(reducer, initialState))
+```
+
 ## Devtools
 
-Yes, it's currently [being hashed out](https://github.com/react-spring/zustand/issues/6) but you can already start using it: https://codesandbox.io/s/amazing-kepler-swxol. It works with regular actions as well, you don't need reducers for this.
+```jsx
+import { devtools } from 'zustand'
+
+// Usage with a plain action store, it will log actions as "setState"
+const [useStore] = create(devtools((set, get => ({ ... })))))
+// Usage with a redux store, it will log full action types
+const [useStore] = create(devtools(redux(reducer, initialState)))
+```

--- a/readme.md
+++ b/readme.md
@@ -228,7 +228,7 @@ const [useStore] = create(redux(reducer, initialState))
 import { devtools } from 'zustand/middleware'
 
 // Usage with a plain action store, it will log actions as "setState"
-const [useStore] = create(devtools((set, get => ({ ... })))))
+const [useStore] = create(devtools(store))
 // Usage with a redux store, it will log full action types
 const [useStore] = create(devtools(redux(reducer, initialState)))
 ```

--- a/readme.md
+++ b/readme.md
@@ -217,7 +217,7 @@ dispatch({ type: types.increase, by: 2 })
 Or, just use our redux-middleware. It wires up your main-reducer, sets initial state, and adds a dispatch function to the state itself and the vanilla api. Try [this](https://codesandbox.io/s/amazing-kepler-swxol) example.
 
 ```jsx
-import { redux } from 'zustand'
+import { redux } from 'zustand/middleware'
 
 const [useStore] = create(redux(reducer, initialState))
 ```
@@ -225,7 +225,7 @@ const [useStore] = create(redux(reducer, initialState))
 ## Devtools
 
 ```jsx
-import { devtools } from 'zustand'
+import { devtools } from 'zustand/middleware'
 
 // Usage with a plain action store, it will log actions as "setState"
 const [useStore] = create(devtools((set, get => ({ ... })))))

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,4 +41,7 @@ function createConfig(entry, out) {
   ]
 }
 
-export default [...createConfig('src/index.ts', 'index')]
+export default [
+  ...createConfig('src/index.ts', 'index'),
+  ...createConfig('src/middleware.ts', 'middleware'),
+]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,7 @@ function createConfig(entry, out) {
     },
     {
       input: entry,
-      output: { file: `dist/${out}.cjs.js`, format: 'cjs' },
+      output: { file: `dist/${out}.cjs.js`, format: 'cjs', exports: 'named' },
       external,
       plugins: [
         typescript(),
@@ -41,7 +41,4 @@ function createConfig(entry, out) {
   ]
 }
 
-export default [
-  ...createConfig('src/index.ts', 'index'),
-  ...createConfig('src/middleware.ts', 'middleware'),
-]
+export default [...createConfig('src/index.ts', 'index')]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useReducer, useRef } from 'react'
 import shallowEqual from './shallowEqual'
+import { redux, devtools } from './middleware'
 
 export type State = Record<string | number | symbol, any>
 export type StateListener<T extends State, U = T> = (state: U) => void
@@ -131,4 +132,4 @@ export default function create<TState extends State>(
   return [useStore, api]
 }
 
-export { shallowEqual }
+export { shallowEqual, redux, devtools }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { useEffect, useLayoutEffect, useReducer, useRef } from 'react'
 import shallowEqual from './shallowEqual'
-import { redux, devtools } from './middleware'
 
 export type State = Record<string | number | symbol, any>
 export type StateListener<T extends State, U = T> = (state: U) => void
@@ -132,4 +131,4 @@ export default function create<TState extends State>(
   return [useStore, api]
 }
 
-export { shallowEqual, redux, devtools }
+export { shallowEqual }

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -270,7 +270,6 @@ it('can fetch multiple entries with shallow equality', async () => {
   act(() => {
     setState({ c: 1 })
   })
-  //await waitForElement(() => getByText('a: 1 b: 1'))
 
   expect(renderCount).toBe(2)
 })

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -7,6 +7,7 @@ import {
   waitForElement,
 } from '@testing-library/react'
 import create, {
+  shallowEqual,
   GetState,
   PartialState,
   SetState,
@@ -18,7 +19,6 @@ import create, {
   UseStore,
 } from '../src/index'
 import { devtools, redux } from '../src/middleware'
-
 afterEach(cleanup)
 
 it('creates a store hook and api object', () => {
@@ -207,9 +207,10 @@ it('can pass optional dependencies to restrict selector calls', () => {
   let selectorCallCount = 0
 
   function Component({ deps }) {
-    useStore(() => {
+    const sel = React.useCallback(() => {
       selectorCallCount++
     }, deps)
+    useStore(sel, deps)
     return <div>{selectorCallCount}</div>
   }
 
@@ -227,7 +228,8 @@ it('can update state without updating dependencies', async () => {
   const [useStore, { setState }] = create(() => ({ value: 0 }))
 
   function Component() {
-    const { value } = useStore(state => state, [])
+    const sel = React.useCallback(state => state, [])
+    const { value } = useStore(sel)
     return <div>value: {value}</div>
   }
 
@@ -238,6 +240,39 @@ it('can update state without updating dependencies', async () => {
     setState({ value: 1 })
   })
   await waitForElement(() => getByText('value: 1'))
+})
+
+it('can fetch multiple entries with shallow equality', async () => {
+  const [useStore, { setState }] = create(() => ({ a: 0, b: 0, c: 0 }))
+
+  let renderCount = 0
+  function Component() {
+    renderCount++
+    const { a, b } = useStore(
+      state => ({ a: state.a, b: state.b }),
+      shallowEqual
+    )
+    return (
+      <div>
+        a: {a} b: {b}
+      </div>
+    )
+  }
+
+  const { getByText } = render(<Component />)
+  await waitForElement(() => getByText('a: 0 b: 0'))
+
+  act(() => {
+    setState({ a: 1, b: 1 })
+  })
+  await waitForElement(() => getByText('a: 1 b: 1'))
+
+  act(() => {
+    setState({ c: 1 })
+  })
+  //await waitForElement(() => getByText('a: 1 b: 1'))
+
+  expect(renderCount).toBe(2)
 })
 
 it('can use exposed types', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1658,6 +1658,11 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+  integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
+
 camelcase@^5.0.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -1886,6 +1891,18 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copyfiles@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.1.0.tgz#0e2a4188162d6b2f3c5adfe34e9c0bd564d23164"
+  integrity sha512-cAeDE0vL/koE9WSEGxqPpSyvU638Kgfu6wfrnj7kqp9FWa1CWsU54Coo6sdYZP4GstWa39tL/wIVJWfXcujgNA==
+  dependencies:
+    glob "^7.0.5"
+    minimatch "^3.0.3"
+    mkdirp "^0.5.1"
+    noms "0.0.0"
+    through2 "^2.0.1"
+    yargs "^11.0.0"
+
 core-js-compat@^3.1.1:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.1.4.tgz#e4d0c40fbd01e65b1d457980fe4112d4358a7408"
@@ -1945,6 +1962,15 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cross-spawn@^6.0.0:
   version "6.0.5"
@@ -2043,7 +2069,7 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.2.0:
+decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -2345,6 +2371,19 @@ exec-sh@^0.3.2:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
   integrity sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==
 
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  integrity sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -2493,6 +2532,13 @@ find-cache-dir@^2.0.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
+find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
+  dependencies:
+    locate-path "^2.0.0"
+
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -2637,6 +2683,11 @@ get-stdin@^7.0.0:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
   integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
 
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
+
 get-stream@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
@@ -2664,7 +2715,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
@@ -2946,6 +2997,11 @@ invariant@^2.2.2, invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
+invert-kv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+  integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
+
 invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
@@ -3177,6 +3233,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -3716,6 +3777,11 @@ json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
+json@^9.0.6:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/json/-/json-9.0.6.tgz#7972c2a5a48a42678db2730c7c2c4ee6e4e24585"
+  integrity sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -3761,6 +3827,13 @@ kleur@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
+lcid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
+  integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
+  dependencies:
+    invert-kv "^1.0.0"
 
 lcid@^2.0.0:
   version "2.0.0"
@@ -3885,6 +3958,14 @@ loader-utils@^1.1.0, loader-utils@^1.2.3:
     emojis-list "^2.0.0"
     json5 "^1.0.1"
 
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -3939,6 +4020,14 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+lru-cache@^4.0.1:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -4008,6 +4097,13 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+mem@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
+  integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
+  dependencies:
+    mimic-fn "^1.0.0"
 
 mem@^4.0.0:
   version "4.3.0"
@@ -4092,7 +4188,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.4:
+minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -4301,6 +4397,14 @@ node-releases@^1.1.23:
   dependencies:
     semver "^5.3.0"
 
+noms@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/noms/-/noms-0.0.0.tgz#da8ebd9f3af9d6760919b27d9cdc8092a7332859"
+  integrity sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "~1.0.31"
+
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
@@ -4477,6 +4581,15 @@ os-homedir@^1.0.0:
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
+os-locale@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
+  integrity sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==
+  dependencies:
+    execa "^0.7.0"
+    lcid "^1.0.0"
+    mem "^1.1.0"
+
 os-locale@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
@@ -4521,12 +4634,26 @@ p-is-promise@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+  dependencies:
+    p-try "^1.0.0"
+
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
   integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
   dependencies:
     p-try "^2.0.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
+  dependencies:
+    p-limit "^1.1.0"
 
 p-locate@^3.0.0:
   version "3.0.0"
@@ -4556,6 +4683,11 @@ p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
   integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -4809,6 +4941,11 @@ prr@~1.0.1:
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
+
 psl@^1.1.24, psl@^1.1.28:
   version "1.1.33"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.33.tgz#5533d9384ca7aab86425198e10e8053ebfeab661"
@@ -4970,6 +5107,16 @@ read-pkg@^5.1.1:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@~1.0.31:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readdirp@^2.2.1:
   version "2.2.1"
@@ -5671,6 +5818,11 @@ string_decoder@^1.0.0:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -5824,7 +5976,7 @@ throat@^4.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
   integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
 
-through2@^2.0.0:
+through2@^2.0.0, through2@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
@@ -6297,10 +6449,20 @@ xtend@^4.0.0, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
   integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
 
+y18n@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
+
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.0.3"
@@ -6314,6 +6476,31 @@ yargs-parser@^11.1.1:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^12.0.2:
   version "12.0.5"


### PR DESCRIPTION
equality: https://github.com/react-spring/zustand/issues/36
try/catch: https://github.com/react-spring/zustand/pull/37

all tests seem to work, docs are updated

This would be a breaking change (major) since the useStore fn signature was slightly adjusted, removing dependencies (which are pretty much useless ever since we merged @JeremyRH's referened-selectors) in favour of an optional equality function.

It also adds basic middleware officially.

## Selecting multiple state slices

zustand defaults to strict-equality (old === new) to detect changes, this is efficient for atomic state picks. 

```jsx
const foo = useStore(state => state.foo)
const bar = useStore(state => state.bar)
```

If you want to construct a single object with multiple state-picks inside, similar to redux's mapStateToProps, you can tell zustand that you want the object to be diffed shallowly.

```jsx
import { shallowEqual } from 'zustand'

const { foo, bar } = useStore(state => ({ foo: state.foo, bar: state.bar }), shallowEqual)
```

## Memoizing selectors

Selectors run on state changes, as well as when the component renders. If you give zustand a fixed reference it will only run on state changes, or when the selector changes. Don't worry about this, unless your selector is expensive.

```js
const fooSelector = useCallback(state => state.foo[props.id], [props.id])
const foo = useStore(fooSelector)
```

## Can't live without redux-like reducers and action types?

```jsx
const types = { increase: "INCREASE", decrease: "DECREASE" }

const reducer = (state, { type, by = 1 }) => {
  switch (type) {
    case types.increase: return { count: state.count + by }
    case types.decrease: return { count: state.count - by }
  }
}

const [useStore] = create(set => ({
  count: 0,
  dispatch: args => set(state => reducer(state, args)),
}))

const dispatch = useStore(state => state.dispatch)
dispatch({ type: types.increase, by: 2 })
```

Or, just use our redux-middleware. It wires up your main-reducer, sets initial state, and adds a dispatch function to the state itself and the vanilla api. Try [this](https://codesandbox.io/s/amazing-kepler-swxol) example.

```jsx
import { redux } from 'zustand/middleware'

const [useStore] = create(redux(reducer, initialState))
```

## Devtools

```jsx
import { devtools } from 'zustand/middleware'

// Usage with a plain action store, it will log actions as "setState"
const [useStore] = create(devtools(store))
// Usage with a redux store, it will log full action types
const [useStore] = create(devtools(redux(reducer, initialState)))
```