### PR TITLE
Add IIFE build

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 2902,
-    "minified": 1064,
-    "gzipped": 532,
+    "bundled": 2921,
+    "minified": 1079,
+    "gzipped": 535,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,9 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 3639,
-    "minified": 1297,
-    "gzipped": 609
+    "bundled": 3664,
+    "minified": 1319,
+    "gzipped": 616
+  },
+  "dist/index.iife.js": {
+    "bundled": 3843,
+    "minified": 1155,
+    "gzipped": 554
   },
   "dist/middleware.js": {
     "bundled": 1365,
@@ -36,5 +41,10 @@
     "bundled": 2068,
     "minified": 1096,
     "gzipped": 579
+  },
+  "dist/middleware.iife.js": {
+    "bundled": 2202,
+    "minified": 1012,
+    "gzipped": 539
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import resolve from 'rollup-plugin-node-resolve'
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot'
 import typescript from 'rollup-plugin-typescript2'
 
+const packageJson = require('./package.json')
 const getBabelRc = require('./.babelrc.js')
 const root = process.platform === 'win32' ? path.resolve('/') : '/'
 const external = id => !id.startsWith('.') && !id.startsWith(root)
@@ -30,6 +31,25 @@ function createConfig(entry, out) {
     {
       input: entry,
       output: { file: `dist/${out}.cjs.js`, format: 'cjs', exports: 'named' },
+      external,
+      plugins: [
+        typescript(),
+        babel(getBabelOptions()),
+        sizeSnapshot(),
+        resolve({ extensions }),
+      ],
+    },
+    {
+      input: entry,
+      output: {
+        file: `dist/${out}.iife.js`,
+        format: 'iife',
+        exports: 'named',
+        name: packageJson.name,
+        globals: {
+          react: 'React',
+        },
+      },
       external,
       plugins: [
         typescript(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,3 +131,5 @@ export default function create<TState extends State>(
 
   return [useStore, api]
 }
+
+export { create }


### PR DESCRIPTION
Hey! I have a need to drop zustand into a tampermonkey script, but there was no UMD build. I'm not a huge fan of UMD and it seems like you're trying really hard to keep the bytes down so I went with IIFE.

I added 'create' to the exports because `zustand.default(set =>...)` is ick. It increases your bundle sizes, though. I don't mind either way.