### PR TITLE
Incorrect display of messages in devtools redux

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,7 +5,11 @@ const redux = (reducer: any, initial: any) => (
 ) => {
   api.dispatch = (action: any) => {
     set((state: any) => reducer(state, action))
-    api.devtools && api.devtools.send(api.devtools.prefix + action, get())
+    const actionWithPrefix = {
+      ...action,
+      type: api.devtools.prefix + action.type
+    } 
+    api.devtools && api.devtools.send(actionWithPrefix, get())
     return action
   }
   return { dispatch: api.dispatch, ...initial }


### PR DESCRIPTION
Incorrect display of messages in devtools redux.

<img width="1870" alt="Снимок экрана 2019-08-15 в 15 07 12" src="https://user-images.githubusercontent.com/25130499/63093707-e91fe480-bf6e-11e9-8452-ee257b091b5b.png">
