### PR TITLE
Support batched updates

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "dist/index.js": {
-    "bundled": 3082,
+    "bundled": 3081,
     "minified": 1283,
     "gzipped": 668,
     "treeshaked": {
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 3825,
-    "minified": 1523,
+    "bundled": 3824,
+    "minified": 1524,
     "gzipped": 750
   },
   "dist/index.iife.js": {
-    "bundled": 4008,
-    "minified": 1359,
-    "gzipped": 685
+    "bundled": 4007,
+    "minified": 1360,
+    "gzipped": 686
   },
   "dist/middleware.js": {
     "bundled": 1482,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export interface StoreApi<T extends State> {
   destroy: Destroy
 }
 
-const forceUpdateReducer = (state: boolean) => !state
+const forceUpdateReducer = (state: number) => state + 1
 // For server-side rendering: https://github.com/react-spring/zustand/pull/34
 const useIsoLayoutEffect =
   typeof window === 'undefined' ? useEffect : useLayoutEffect
@@ -122,7 +122,7 @@ export default function create<TState extends State>(
       options.subscribeError = undefined
     })
 
-    const forceUpdate = useReducer(forceUpdateReducer, false)[1]
+    const forceUpdate = useReducer(forceUpdateReducer, 1)[1]
     useIsoLayoutEffect(() => subscribe(forceUpdate, options), [])
 
     return options.currentSlice as StateSlice

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import ReactDOM from 'react-dom'
 import { act } from 'react-dom/test-utils'
 import {
   cleanup,
@@ -155,6 +156,28 @@ it('only re-renders if selected state has changed', async () => {
 
   expect(counterRenderCount).toBe(2)
   expect(controlRenderCount).toBe(1)
+})
+
+it('can batch updates', async () => {
+  const [useStore] = create(set => ({
+    count: 0,
+    inc: () => set(state => ({ count: state.count + 1 })),
+  }))
+
+  function Counter() {
+    const { count, inc } = useStore()
+    React.useEffect(() => {
+      ReactDOM.unstable_batchedUpdates(() => {
+        inc()
+        inc()
+      })
+    }, [])
+    return <div>count: {count}</div>
+  }
+
+  const { getByText } = render(<Counter />)
+
+  await waitForElement(() => getByText('count: 2'))
 })
 
 it('can update the selector', async () => {


### PR DESCRIPTION
React may sometimes batch updates (e.g. event listeners, maybe more in future). The current implementation of `forceUpdate` does not work when an even number of updates are batched. The added test fails on master.