### PR TITLE
Remove optional catch binding

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -24,9 +24,9 @@
     "gzipped": 686
   },
   "dist/middleware.js": {
-    "bundled": 1482,
-    "minified": 759,
-    "gzipped": 425,
+    "bundled": 1491,
+    "minified": 762,
+    "gzipped": 427,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -38,12 +38,12 @@
     }
   },
   "dist/middleware.cjs.js": {
-    "bundled": 2185,
+    "bundled": 2184,
     "minified": 1170,
     "gzipped": 595
   },
   "dist/middleware.iife.js": {
-    "bundled": 2324,
+    "bundled": 2323,
     "minified": 1089,
     "gzipped": 565
   },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,7 +21,7 @@ const devtools = (fn: any, prefix?: string) => (
     extension =
       (window as any).__REDUX_DEVTOOLS_EXTENSION__ ||
       (window as any).top.__REDUX_DEVTOOLS_EXTENSION__
-  } catch {}
+  } catch (_error) {}
   let ignoreState = false
 
   if (!extension) {


### PR DESCRIPTION
Not sure if you agree to this change.

Optional bindings are currently stage 4 so they will land in the next release, although I've been having issues when running tests with jest since our node version is below 10.

There is also the option of us transpiling zustand prior to running tests.