### PR TITLE
Adjust type inference for store without a selector

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export type StateCreator<T extends State> = (
 ) => T
 export type SetState<T extends State> = (partial: PartialState<T>) => void
 export type GetState<T extends State> = () => T
+export type ReturnState<T extends State, U> = U extends T ? T : U
 export type Subscribe<T extends State> = <U>(
   listener: StateListener<U | void>,
   options?: SubscribeOptions<T, U>
@@ -28,7 +29,7 @@ export type Destroy = () => void
 export type UseStore<T extends State> = <U>(
   selector?: StateSelector<T, U>,
   equalityFn?: EqualityChecker<U>
-) => U
+) => ReturnState<T, U>
 export interface StoreApi<T extends State> {
   setState: SetState<T>
   getState: GetState<T>
@@ -91,7 +92,7 @@ export default function create<TState extends State>(
   const useStore = <StateSlice>(
     selector: StateSelector<TState, StateSlice> = getState,
     equalityFn: EqualityChecker<StateSlice> = Object.is
-  ): StateSlice => {
+  ): ReturnState<TState, StateSlice> => {
     if (Array.isArray(equalityFn)) {
       equalityFn = Object.is
       console.warn(
@@ -126,7 +127,7 @@ export default function create<TState extends State>(
     const forceUpdate = useReducer(forceUpdateReducer, 1)[1]
     useIsoLayoutEffect(() => subscribe(forceUpdate, options), [])
 
-    return options.currentSlice as StateSlice
+    return options.currentSlice as ReturnState<TState, StateSlice>
   }
 
   const api = { setState, getState, subscribe, destroy }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,16 +20,15 @@ export type StateCreator<T extends State> = (
 ) => T
 export type SetState<T extends State> = (partial: PartialState<T>) => void
 export type GetState<T extends State> = () => T
-export type ReturnState<T extends State, U> = U extends T ? T : U
 export type Subscribe<T extends State> = <U>(
   listener: StateListener<U | void>,
   options?: SubscribeOptions<T, U>
 ) => () => void
 export type Destroy = () => void
-export type UseStore<T extends State> = <U>(
-  selector?: StateSelector<T, U>,
-  equalityFn?: EqualityChecker<U>
-) => ReturnState<T, U>
+export interface UseStore<T extends State> {
+  (): T
+  <U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): U
+}
 export interface StoreApi<T extends State> {
   setState: SetState<T>
   getState: GetState<T>
@@ -92,7 +91,7 @@ export default function create<TState extends State>(
   const useStore = <StateSlice>(
     selector: StateSelector<TState, StateSlice> = getState,
     equalityFn: EqualityChecker<StateSlice> = Object.is
-  ): ReturnState<TState, StateSlice> => {
+  ) => {
     if (Array.isArray(equalityFn)) {
       equalityFn = Object.is
       console.warn(
@@ -127,7 +126,7 @@ export default function create<TState extends State>(
     const forceUpdate = useReducer(forceUpdateReducer, 1)[1]
     useIsoLayoutEffect(() => subscribe(forceUpdate, options), [])
 
-    return options.currentSlice as ReturnState<TState, StateSlice>
+    return options.currentSlice
   }
 
   const api = { setState, getState, subscribe, destroy }


### PR DESCRIPTION
This improvement will help with type inference when using `useStore` without selectors.
For example
```
import create from 'zustand'

interface IState {
  count: number;
  increase: () => void;
  reset: () => void;
}

const [useStore] = create<IState>(set => ({
  count: 0,
  increase: () => set(state => ({ count: state.count + 1 })),
  reset: () => set({ count: 0 })
}));

function Counter() {
  const { count, increase, reset } = useStore()
  
  // typeof count === 'number' => true
  // typeof increase === 'function' => true
  // typeof reset === 'function' => true

  return <h1>{count}</h1>
}

```