### PR TITLE
2.1.x // Type changes and perf/bug fixes.

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 3774,
-    "minified": 1232,
-    "gzipped": 589,
+    "bundled": 4474,
+    "minified": 1116,
+    "gzipped": 579,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 4707,
-    "minified": 1493,
-    "gzipped": 678
+    "bundled": 5152,
+    "minified": 1414,
+    "gzipped": 647
   },
   "dist/index.iife.js": {
-    "bundled": 4934,
-    "minified": 1329,
-    "gzipped": 619
+    "bundled": 5387,
+    "minified": 1288,
+    "gzipped": 599
   },
   "dist/shallow.js": {
     "bundled": 646,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zustand",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "🐻 Bear necessities for state management in React",
   "main": "index.cjs.js",
   "module": "index.js",

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -13,7 +13,7 @@ import create, {
   StateSelector,
   PartialState,
   EqualityChecker,
-  SubscribeOptions,
+  Subscriber,
   StateCreator,
   SetState,
   GetState,
@@ -562,11 +562,14 @@ it('can use exposed types', () => {
     },
   })
 
-  const subscribeOptions: SubscribeOptions<ExampleState, number> = {
-    selector: s => s.num,
-    equalityFn: (a, b) => a < b,
+  const subscriber: Subscriber<ExampleState, number> = {
+    callback: () => {},
     currentSlice: 1,
-    subscribeError: new Error(),
+    equalityFn: Object.is,
+    errored: false,
+    index: 0,
+    listener(n: number) {},
+    selector,
   }
 
   function checkAllTypes(
@@ -582,7 +585,7 @@ it('can use exposed types', () => {
     equalityFn: EqualityChecker<ExampleState>,
     stateCreator: StateCreator<ExampleState>,
     useStore: UseStore<ExampleState>,
-    subscribeOptions: SubscribeOptions<ExampleState, number>
+    subscribeOptions: Subscriber<ExampleState, number>
   ) {
     expect(true).toBeTruthy()
   }
@@ -600,6 +603,6 @@ it('can use exposed types', () => {
     equlaityFn,
     stateCreator,
     useStore,
-    subscribeOptions
+    subscriber
   )
 })


### PR DESCRIPTION
I uncovered a couple issues that lead to these changes. Sparse arrays (arrays with holes) seem to have poor performance when their length grows too large (even if they are empty). I wasn't limiting the subscriber counter so it would potentially assign a large index to the subscribers array and cause the `forEach` loop in `setState` to have performance issues. I fixed that by consolidating the subscribers array during `setState`. This minimally impacts performance for every call to `setState` and greatly improves performance in applications that are long running and/or have many renders per second.

The changes lead to a small refactor and unfortunately, some types changed. Good news is these types are used for internal functionality so our public API hasn't changed.

I also found an issue with concurrent mode. The state slice was being updated during the render phase when a new selector was passed in. If the render is interrupted after the slice updates, the next `setState` call won't update the component in some cases.

Anyway, here is the change list.

- Removed SubscribeOptions and UseStoreSubscribeOptions types.
- Added Subscriber type.
- Improve performance by consolidating subscribers sparse array.
- Fix potential issue with concurrent mode.