### PR TITLE
Fix type inference of TypeScript for `shallow` by removing `any`

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -29,8 +29,8 @@
     "gzipped": 256
   },
   "dist/middleware.js": {
-    "bundled": 2126,
-    "minified": 1205,
-    "gzipped": 621
+    "bundled": 2127,
+    "minified": 1206,
+    "gzipped": 622
   }
 }

--- a/src/shallow.ts
+++ b/src/shallow.ts
@@ -1,4 +1,7 @@
-export default function shallow(objA: any, objB: any) {
+export default function shallow<T extends any, U extends any>(
+  objA: T,
+  objB: U
+) {
   if (Object.is(objA, objB)) {
     return true
   }


### PR DESCRIPTION
As the title says.

`useStore` also infers the return type via `EqualityChecker<U>`, so the current types of `shallow` would always make TypeScript infer the return type as `any`.

This PR adds more constraints to `obj1` and `obj2` in `shallow`.