### PR TITLE
Fix subscriber being overwritten

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 4474,
+    "bundled": 4024,
     "minified": 1116,
-    "gzipped": 579,
+    "gzipped": 581,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 5152,
-    "minified": 1414,
-    "gzipped": 647
+    "bundled": 4680,
+    "minified": 1398,
+    "gzipped": 653
   },
   "dist/index.iife.js": {
-    "bundled": 5387,
-    "minified": 1288,
-    "gzipped": 599
+    "bundled": 4909,
+    "minified": 1272,
+    "gzipped": 605
   },
   "dist/shallow.js": {
     "bundled": 646,

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ export default function create<TState extends State>(
     // subscibers in a top-down order. The subscribers array will become a
     // sparse array when an index is skipped (due to an interrupted render) or
     // a component unmounts and the subscriber is deleted. It's converted back
-    // to a dense array in when a subscriber unsubscribes.
+    // to a dense array when a subscriber unsubscribes.
     subscribers[subscriber.index] = subscriber
 
     return () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,21 +59,6 @@ export default function create<TState extends State>(
       typeof partial === 'function' ? partial(state) : partial
     if (partialState !== state) {
       state = Object.assign({}, state, partialState)
-      // Reset subscriberCount because we will be removing holes from the
-      // subscribers array and changing the length which should be the same as
-      // subscriberCount.
-      subscriberCount = 0
-      // Create a dense array by removing holes from the subscribers array.
-      // Holes are not iterated by Array.prototype.filter.
-      subscribers = subscribers.filter(subscriber => {
-        subscriber.index = subscriberCount++
-        return true
-      })
-
-      // Call all subscribers only after the subscribers array has been changed
-      // to a dense array. Subscriber callbacks cannot be called above in
-      // subscribers.filter because the callbacks can cause a synchronous
-      // increment of subscriberCount if not batched.
       subscribers.forEach(subscriber => subscriber.callback())
     }
   }
@@ -115,13 +100,23 @@ export default function create<TState extends State>(
     // subscibers in a top-down order. The subscribers array will become a
     // sparse array when an index is skipped (due to an interrupted render) or
     // a component unmounts and the subscriber is deleted. It's converted back
-    // to a dense array in setState.
+    // to a dense array in when a subscriber unsubscribes.
     subscribers[subscriber.index] = subscriber
 
-    // Delete creates a hole and preserves the array length. If we used
-    // Array.prototype.splice, subscribers with a greater subscriber.index
-    // would no longer match their actual index in subscribers.
-    return () => delete subscribers[subscriber.index]
+    return () => {
+      // Reset subscriberCount because we will be removing holes from the
+      // subscribers array and changing the length which should be the same as
+      // subscriberCount.
+      subscriberCount = 0
+      // Create a dense array by removing holes from the subscribers array.
+      // Holes are not iterated by Array.prototype.filter.
+      subscribers = subscribers.filter(s => {
+        if (s !== subscriber) {
+          subscriber.index = subscriberCount++
+          return true
+        }
+      })
+    }
   }
 
   const apiSubscribe: ApiSubscribe<TState> = <StateSlice>(


### PR DESCRIPTION
@jhgg
Should fix #84 
Here was the problem:
- Subscriber object is created during the render phase and its index is assigned.
- `setState` is called before the subscriber object is added to `subscribers` array (between render phase and `useLayoutEffect`).
- `subscribers` array is made dense, changing the length of the array and indices of subscribers.
- Subscriber object is added to `subscribers` array at wrong index, overwriting a valid subscriber.

I moved the code that makes `subscribers` a dense array into the "unmount" phase (return function of `useLayoutEffect` callback).