### PR TITLE
Change so subscribers are added in render phase

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 4021,
-    "minified": 1116,
-    "gzipped": 581,
+    "bundled": 4156,
+    "minified": 1158,
+    "gzipped": 594,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 4677,
-    "minified": 1398,
-    "gzipped": 653
+    "bundled": 4857,
+    "minified": 1439,
+    "gzipped": 667
   },
   "dist/index.iife.js": {
-    "bundled": 4906,
-    "minified": 1272,
-    "gzipped": 605
+    "bundled": 5096,
+    "minified": 1313,
+    "gzipped": 623
   },
   "dist/shallow.js": {
     "bundled": 646,


### PR DESCRIPTION
This fixes an issue with subscriber indices being overriden in some cases, as seen in issue #86. In this scenario, child components will unmount between the render phase of the parent and its layout effect triggering. This causes indices to become invalid since the array is compressed as a result of a component unsubscribing (when it unmounts). 

With this, instead of only assigning the index in the render phase, the subscriber is also added to the array of subscribers, so that there are no pending indices when subsequent unsubscribe functions are called.

This also handles the case in #84.

I'm not sure what the reason was for assigning an index and adding the subscriber in different phases, so please let me know if I missed something.