### PR TITLE
Fix typing of PartialState<T> for immer usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export type State = Record<string | number | symbol, any>
 export type PartialState<T extends State> =
   | Partial<T>
   | ((state: T) => Partial<T>)
+  | ((state: T) => void)
 export type StateCreator<T extends State> = (
   set: SetState<T>,
   get: GetState<T>,


### PR DESCRIPTION
This fixes #96.