### PR TITLE
Add better type inference

### DIFF
--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -11,6 +11,7 @@ import create, {
   State,
   StateListener,
   StateSelector,
+  StateGetterSelectorIntersection,
   PartialState,
   EqualityChecker,
   Subscriber,
@@ -619,22 +620,24 @@ it('can use exposed types', () => {
   const equlaityFn: EqualityChecker<ExampleState> = (state, newState) =>
     state !== newState
 
-  const [useStore, storeApi] = create<ExampleState>((set, get) => ({
-    num: 1,
-    numGet: () => get().num,
-    numGetState: () => {
-      // TypeScript can't get the type of storeApi when it trys to enforce the signature of numGetState.
-      // Need to explicitly state the type of storeApi.getState().num or storeApi type will be type 'any'.
-      const result: number = storeApi.getState().num
-      return result
-    },
-    numSet: v => {
-      set({ num: v })
-    },
-    numSetState: v => {
-      storeApi.setState({ num: v })
-    },
-  }))
+  const [useStore, storeApi] = create<StateCreator<ExampleState>>(
+    (set, get) => ({
+      num: 1,
+      numGet: () => get().num,
+      numGetState: () => {
+        // TypeScript can't get the type of storeApi when it trys to enforce the signature of numGetState.
+        // Need to explicitly state the type of storeApi.getState().num or storeApi type will be type 'any'.
+        const result: number = storeApi.getState().num
+        return result
+      },
+      numSet: v => {
+        set({ num: v })
+      },
+      numSetState: v => {
+        storeApi.setState({ num: v })
+      },
+    })
+  )
 
   const stateCreator: StateCreator<ExampleState> = (set, get) => ({
     num: 1,


### PR DESCRIPTION
This PR only changes some types, but I think that it will have a huge impact in the developer experience, as the types will be inferred based in the `StateCreator` type.

One caveat with this PR is that the generic of `create` has been changed from `TState extends State` to `TStateCreator extends StateCreator<State>` to allow better inference (see [this line][ref-1]). Another "generic argument" was added to, but that one should not be touched by the end user. In this last case, the second "generic argument" could be avoided with a little code duplication. What do you think?

This should be treated as a breaking change, as the generic constraint have been changed.

<details>
  <summary>Some screenshots of VSCode showing the new type inference</summary>

![image](https://user-images.githubusercontent.com/23662020/83334440-eb90c800-a27c-11ea-9d41-d69f153a497a.png)
![image](https://user-images.githubusercontent.com/23662020/83334445-f6e3f380-a27c-11ea-9ad1-0fd949f3e662.png)
![image](https://user-images.githubusercontent.com/23662020/83334450-05caa600-a27d-11ea-8f6f-774728d86788.png)
![image](https://user-images.githubusercontent.com/23662020/83334474-31e62700-a27d-11ea-9897-cf395558bdc0.png)

</details>

  [ref-1]: https://github.com/lffg-forks/zustand/blob/a20deae6a4fc8a92ae00eda42e0b46b16972e8a7/src/index.ts#L54