### PR TITLE
fix: devtools not showing actions

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -29,8 +29,8 @@
     "gzipped": 256
   },
   "dist/middleware.js": {
-    "bundled": 2127,
-    "minified": 1206,
-    "gzipped": 622
+    "bundled": 2187,
+    "minified": 1245,
+    "gzipped": 639
   }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -52,6 +52,7 @@ const devtools = (fn: any, prefix?: string) => (
       }
     })
     api.devtools.init(initialState)
+    api.devtools.send('zustand connected', initialState)
   }
   return initialState
 }


### PR DESCRIPTION
using devtools did now show my actions as they were dispatched.

While debugging, I found that issuing a manual devtools.send() does something in the redux-devtools-extension to complete the init process, allowing all subsequent actions to be logged.