### PR TITLE
Updates Immer example in readme to prevent "Invalid left-hand side in…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,9 @@ const [useStore] = create(set => ({
 }))
 
 const set = useStore(state => state.set)
-set(state => void state.nested.structure.contains = null)
+set(state => {
+  state.nested.structure.contains = null
+})
 ```
 
 ## Reading/writing state and reacting to changes outside of components


### PR DESCRIPTION
… assignment expression"

Using the code as is in this example causes Invalid left-hand side in assignment expression because we are setting the value rather than doing an increment or something. I ran across this while trying to use this example and have a codesandbox to show this breaking if needed. Please lmk if I am off base here, but this is the code that's actually working for me.