### PR TITLE
feat: new implementation with useMutableSource

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "zustand",
   "private": true,
-  "version": "2.2.4",
+  "version": "3.0.0-alpha.0",
+  "publishConfig": {
+    "tag": "alpha"
+  },
   "description": "🐻 Bear necessities for state management in React",
   "main": "index.cjs.js",
   "module": "index.js",
@@ -94,8 +97,8 @@
     "json": "^9.0.6",
     "lint-staged": "^9.4.2",
     "prettier": "^1.18.2",
-    "react": "^16.11.0",
-    "react-dom": "^16.11.0",
+    "react": "^0.0.0-experimental-94c0244ba",
+    "react-dom": "^0.0.0-experimental-94c0244ba",
     "rimraf": "^3.0.0",
     "rollup": "^1.25.2",
     "rollup-plugin-babel": "^4.3.3",
@@ -105,6 +108,6 @@
     "typescript": "^3.6.4"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": "experimental"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
-import { useEffect, useLayoutEffect, useReducer, useRef } from 'react'
+import {
+  useCallback,
+  useMemo,
+  // @ts-ignore
+  unstable_createMutableSource as createMutableSource,
+  // @ts-ignore
+  unstable_useMutableSource as useMutableSource,
+} from 'react'
 
 export type State = Record<string | number | symbol, any>
 export type PartialState<T extends State> =
@@ -42,10 +49,6 @@ export interface StoreApi<T extends State> {
   subscribe: ApiSubscribe<T>
   destroy: Destroy
 }
-
-// For server-side rendering: https://github.com/react-spring/zustand/pull/34
-const useIsoLayoutEffect =
-  typeof window === 'undefined' ? useEffect : useLayoutEffect
 
 export default function create<TState extends State>(
   createState: StateCreator<TState>
@@ -110,50 +113,60 @@ export default function create<TState extends State>(
 
   const destroy: Destroy = () => listeners.clear()
 
+  // The first param can be anything stable
+  const source = createMutableSource(getState, () => state)
+
+  const FUNCTION_SYNBOL = Symbol()
+  const functionMap = new WeakMap<Function, { [FUNCTION_SYNBOL]: Function }>()
+
   const useStore: UseStore<TState> = <StateSlice>(
     selector: StateSelector<TState, StateSlice> = getState,
     equalityFn: EqualityChecker<StateSlice> = Object.is
   ) => {
-    const forceUpdate: StateListener<StateSlice> = useReducer(c => c + 1, 0)[1]
-    const subscriberRef = useRef<Subscriber<TState, StateSlice>>()
-
-    if (!subscriberRef.current) {
-      subscriberRef.current = getSubscriber(forceUpdate, selector, equalityFn)
-      subscriberRef.current.unsubscribe = subscribe(subscriberRef.current)
-    }
-
-    const subscriber = subscriberRef.current
-    let newStateSlice: StateSlice | undefined
-    let hasNewStateSlice = false
-
-    // The selector or equalityFn need to be called during the render phase if
-    // they change. We also want legitimate errors to be visible so we re-run
-    // them if they errored in the subscriber.
-    if (
-      subscriber.selector !== selector ||
-      subscriber.equalityFn !== equalityFn ||
-      subscriber.errored
-    ) {
-      // Using local variables to avoid mutations in the render phase.
-      newStateSlice = selector(state)
-      hasNewStateSlice = !equalityFn(subscriber.currentSlice, newStateSlice)
-    }
-
-    // Syncing changes in useEffect.
-    useIsoLayoutEffect(() => {
-      if (hasNewStateSlice) {
-        subscriber.currentSlice = newStateSlice as StateSlice
+    // cache to avoid double invoking selector
+    const cachedSlices = useMemo(() => new WeakMap<TState, StateSlice>(), [
+      selector,
+      equalityFn,
+    ])
+    const sub = useCallback(
+      (_, callback) => {
+        const listener = (nextSlice: StateSlice | null) => {
+          if (nextSlice === null) {
+            cachedSlices.delete(state) // XXX never delete anything
+            subscriber.errored = false
+          } else {
+            cachedSlices.set(state, nextSlice)
+          }
+          callback()
+        }
+        const subscriber = getSubscriber(listener, selector, equalityFn)
+        return subscribe(subscriber)
+      },
+      [selector, equalityFn]
+    )
+    const getSnapshot = useCallback(() => {
+      const slice = cachedSlices.has(state)
+        ? cachedSlices.get(state)
+        : selector(state)
+      // https://github.com/facebook/react/issues/18823
+      if (typeof slice === 'function') {
+        if (functionMap.has(slice)) {
+          return functionMap.get(slice)
+        }
+        const wrappedFunction = { [FUNCTION_SYNBOL]: slice }
+        functionMap.set(slice, wrappedFunction)
+        return wrappedFunction
       }
-      subscriber.selector = selector
-      subscriber.equalityFn = equalityFn
-      subscriber.errored = false
-    })
-
-    useIsoLayoutEffect(() => subscriber.unsubscribe, [])
-
-    return hasNewStateSlice
-      ? (newStateSlice as StateSlice)
-      : subscriber.currentSlice
+      return slice
+    }, [selector])
+    const snapshot = useMutableSource(source, getSnapshot, sub)
+    if (
+      snapshot &&
+      (snapshot as { [FUNCTION_SYNBOL]: unknown })[FUNCTION_SYNBOL]
+    ) {
+      return snapshot[FUNCTION_SYNBOL]
+    }
+    return snapshot
   }
 
   const api = { setState, getState, subscribe: apiSubscribe, destroy }

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,12 +130,12 @@ export default function create<TState extends State>(
     ])
     const sub = useCallback(
       (_, callback) => {
-        const listener = (nextSlice: StateSlice | null) => {
-          if (nextSlice === null) {
+        const listener = (nextSlice: StateSlice | null, error?: Error) => {
+          if (error) {
             cachedSlices.delete(state) // XXX never delete anything
             subscriber.errored = false
           } else {
-            cachedSlices.set(state, nextSlice)
+            cachedSlices.set(state, nextSlice as StateSlice)
           }
           callback()
         }
@@ -146,7 +146,7 @@ export default function create<TState extends State>(
     )
     const getSnapshot = useCallback(() => {
       const slice = cachedSlices.has(state)
-        ? cachedSlices.get(state)
+        ? (cachedSlices.get(state) as StateSlice)
         : selector(state)
       // https://github.com/facebook/react/issues/18823
       if (typeof slice === 'function') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4152,7 +4152,7 @@ log-update@^2.3.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5029,15 +5029,6 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
-prop-types@^15.6.2:
-  version "15.7.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
-  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.8.1"
-
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -5140,29 +5131,27 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.11.0:
-  version "16.11.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.11.0.tgz#7e7c4a5a85a569d565c2462f5d345da2dd849af5"
-  integrity sha512-nrRyIUE1e7j8PaXSPtyRKtz+2y9ubW/ghNgqKFHHAHaeP0fpF5uXR+sq8IMRHC+ZUxw7W9NyCDTBtwWxvkb0iA==
+react-dom@^0.0.0-experimental-94c0244ba:
+  version "0.0.0-experimental-94c0244ba"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-experimental-94c0244ba.tgz#1e715ca62608458058b99303d562ce77d3e699d8"
+  integrity sha512-rvyWGIxrtjImQaeo3/27ORpU5i7fTzPlQH/xkEI/wlLfuJ2zi7Tideln8y9xM2BA5mYA74sH103bMbIQbPWtGQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.17.0"
+    scheduler "0.0.0-experimental-94c0244ba"
 
-react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.8.4:
   version "16.11.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
   integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
 
-react@^16.11.0:
-  version "16.11.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.11.0.tgz#d294545fe62299ccee83363599bf904e4a07fdbb"
-  integrity sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==
+react@^0.0.0-experimental-94c0244ba:
+  version "0.0.0-experimental-94c0244ba"
+  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-experimental-94c0244ba.tgz#eb63ece3eadcf231845b6ec9c4a8c1829ddcc1fe"
+  integrity sha512-67fLM+CA1w96JM0Ju5dv9lE3q1qSxVAi1iAOOyhXddhQJfs85bAJNM+gEMPBKbrhbhJGyHL1mLh1xqpOzokQ4w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-pkg-up@^4.0.0:
   version "4.0.0"
@@ -5569,10 +5558,10 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.17.0.tgz#7c9c673e4ec781fac853927916d1c426b6f3ddfe"
-  integrity sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==
+scheduler@0.0.0-experimental-94c0244ba:
+  version "0.0.0-experimental-94c0244ba"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-experimental-94c0244ba.tgz#0144f590f76a951111fe9f93ccaac7e5b674d04a"
+  integrity sha512-F+eZM/SpbZj8Ugh7AU5dWydx/iwJwI91PGAEEtc01cvO28ojXaxEjBqUscKNNNJM0xUumoFmmDmEOfAr/wKyoA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
This is for next major version.

Some notes:
- It will only work with react@experimental, it may change later, and we are not sure when it will be finalized.
- It's based on useMutableSource, and no longer requires useEffect and useRef.
- The render behavior is slightly changed.
- The behavior with exception is changed. The spec is skipped.
- [IMPORTANT] selectors and equalityFn should be stable. Either make them static or wrap with `useCallback`.
  - However, thanks to scoped subscription (unlike Redux), unstable selectors seem to work.
- On the other hand, it needs to cache the selector result `cachedSlices`, which is a bit hacky.
- `functionMap` is hacky too, but can't be helped.
- Needs someone to review the changes in tests, if they are valid or not.
- Bundle size is increased a bit, unfortunately. It could be shaved a bit once we finalize the api.