### PR TITLE
[v3-alpha] clean up types

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 2829,
-    "minified": 897,
-    "gzipped": 492,
+    "bundled": 2922,
+    "minified": 899,
+    "gzipped": 490,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 3406,
-    "minified": 1132,
-    "gzipped": 566
+    "bundled": 3481,
+    "minified": 1125,
+    "gzipped": 564
   },
   "dist/index.iife.js": {
-    "bundled": 3591,
-    "minified": 1049,
-    "gzipped": 525
+    "bundled": 3668,
+    "minified": 1042,
+    "gzipped": 524
   },
   "dist/shallow.js": {
     "bundled": 646,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,27 +1,27 @@
 {
   "dist/index.js": {
-    "bundled": 3173,
-    "minified": 1109,
-    "gzipped": 558,
+    "bundled": 2829,
+    "minified": 897,
+    "gzipped": 492,
     "treeshaked": {
       "rollup": {
         "code": 14,
         "import_statements": 14
       },
       "webpack": {
-        "code": 1061
+        "code": 998
       }
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 3816,
-    "minified": 1368,
-    "gzipped": 630
+    "bundled": 3406,
+    "minified": 1132,
+    "gzipped": 566
   },
   "dist/index.iife.js": {
-    "bundled": 4015,
-    "minified": 1242,
-    "gzipped": 586
+    "bundled": 3591,
+    "minified": 1049,
+    "gzipped": 525
   },
   "dist/shallow.js": {
     "bundled": 646,

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,9 +83,11 @@ export default function create<TState extends State>(
     return unsubscribe
   }
 
-  const destroy: Destroy = () => listeners.clear()
+  const destroy: Destroy = () => {
+    listeners.clear()
+  }
 
-  // The first param can be anything stable
+  // The first param can be anything stable within this closure
   const source = createMutableSource(getState, () => state)
 
   const FUNCTION_SYNBOL = Symbol()
@@ -116,6 +118,7 @@ export default function create<TState extends State>(
       const slice = cachedSlices.has(state)
         ? (cachedSlices.get(state) as StateSlice)
         : selector(state)
+      // Unfortunately, returning a function is not supported
       // https://github.com/facebook/react/issues/18823
       if (typeof slice === 'function') {
         if (functionMap.has(slice)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export type State = Record<string | number | symbol, any>
 export type PartialState<T extends State> =
   | Partial<T>
   | ((state: T) => Partial<T>)
+  | ((state: T) => void) // for immer https://github.com/react-spring/zustand/pull/99
 export type StateSelector<T extends State, U> = (state: T) => U
 export type EqualityChecker<T> = (state: T, newState: any) => boolean
 

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -13,11 +13,10 @@ import create, {
   StateSelector,
   PartialState,
   EqualityChecker,
-  Subscriber,
   StateCreator,
   SetState,
   GetState,
-  ApiSubscribe,
+  Subscribe,
   Destroy,
   UseStore,
   StoreApi,
@@ -285,46 +284,6 @@ it('can throw an error in selector', async () => {
 
   function Component() {
     useStore(selector)
-    return <div>no error</div>
-  }
-
-  const { getByText } = render(
-    <ErrorBoundary>
-      <Component />
-    </ErrorBoundary>
-  )
-  await waitForElement(() => getByText('no error'))
-
-  delete initialState.value
-  act(() => {
-    setState({})
-  })
-  await waitForElement(() => getByText('errored'))
-})
-
-it.skip('can throw an error in equality checker', async () => {
-  console.error = jest.fn()
-
-  const initialState = { value: 'foo' }
-  const [useStore, { setState }] = create(() => initialState)
-  const selector = s => s
-  const equalityFn = (a, b) => a.value.trim() === b.value.trim()
-
-  class ErrorBoundary extends React.Component<any, { hasError: boolean }> {
-    constructor(props) {
-      super(props)
-      this.state = { hasError: false }
-    }
-    static getDerivedStateFromError() {
-      return { hasError: true }
-    }
-    render() {
-      return this.state.hasError ? <div>errored</div> : this.props.children
-    }
-  }
-
-  function Component() {
-    useStore(selector, equalityFn)
     return <div>no error</div>
   }
 
@@ -654,15 +613,6 @@ it('can use exposed types', () => {
     },
   })
 
-  const subscriber: Subscriber<ExampleState, number> = {
-    currentSlice: 1,
-    equalityFn: Object.is,
-    errored: false,
-    listener(n: number | null) {},
-    selector,
-    unsubscribe: () => {},
-  }
-
   function checkAllTypes(
     getState: GetState<ExampleState>,
     partialState: PartialState<ExampleState>,
@@ -671,12 +621,11 @@ it('can use exposed types', () => {
     stateListener: StateListener<ExampleState>,
     stateSelector: StateSelector<ExampleState, number>,
     storeApi: StoreApi<ExampleState>,
-    subscribe: ApiSubscribe<ExampleState>,
+    subscribe: Subscribe<ExampleState>,
     destroy: Destroy,
     equalityFn: EqualityChecker<ExampleState>,
     stateCreator: StateCreator<ExampleState>,
-    useStore: UseStore<ExampleState>,
-    subscribeOptions: Subscriber<ExampleState, number>
+    useStore: UseStore<ExampleState>
   ) {
     expect(true).toBeTruthy()
   }
@@ -693,7 +642,6 @@ it('can use exposed types', () => {
     storeApi.destroy,
     equlaityFn,
     stateCreator,
-    useStore,
-    subscriber
+    useStore
   )
 })


### PR DESCRIPTION
useMutableSource version doesn't require subscriber, so this simplifies a lot.
Note, this is technically a braking change in the exported types.
I assume people are not extensively using `ApiSubscribe` type in v2.