### PR TITLE
[v3-alpha] unified api

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 3210,
-    "minified": 1004,
-    "gzipped": 534,
+    "bundled": 3183,
+    "minified": 987,
+    "gzipped": 533,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 4186,
-    "minified": 1402,
-    "gzipped": 684
+    "bundled": 4159,
+    "minified": 1385,
+    "gzipped": 683
   },
   "dist/index.iife.js": {
-    "bundled": 4427,
-    "minified": 1319,
-    "gzipped": 647
+    "bundled": 4398,
+    "minified": 1302,
+    "gzipped": 646
   },
   "dist/shallow.js": {
     "bundled": 646,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 2998,
-    "minified": 907,
-    "gzipped": 496,
+    "bundled": 3210,
+    "minified": 1004,
+    "gzipped": 534,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 3555,
-    "minified": 1131,
-    "gzipped": 571
+    "bundled": 4186,
+    "minified": 1402,
+    "gzipped": 684
   },
   "dist/index.iife.js": {
-    "bundled": 3750,
-    "minified": 1048,
-    "gzipped": 531
+    "bundled": 4427,
+    "minified": 1319,
+    "gzipped": 647
   },
   "dist/shallow.js": {
     "bundled": 646,

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,8 +155,7 @@ export default function create<TState extends State>(
   const api = { setState, getState, subscribe, destroy }
   state = createState(setState, getState, api)
 
-  Object.assign(useStore, api)
-  Object.assign(useStore, { useStore })
+  Object.assign(useStore, api, { useStore })
 
   // For backward compatibility (No TS types for this)
   useStore[Symbol.iterator] = function*() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,11 +42,16 @@ export type StateCreator<T extends State> = (
 export interface UseStore<T extends State> {
   (): T
   <U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): U
+  setState: SetState<T>
+  getState: GetState<T>
+  subscribe: Subscribe<T>
+  destroy: Destroy
+  useStore: UseStore<T> // This allows namespace pattern
 }
 
 export default function create<TState extends State>(
   createState: StateCreator<TState>
-): [UseStore<TState>, StoreApi<TState>] {
+): UseStore<TState> {
   let state: TState
   let listeners: Set<() => void> = new Set()
 
@@ -100,7 +105,7 @@ export default function create<TState extends State>(
   const FUNCTION_SYNBOL = Symbol()
   const functionMap = new WeakMap<Function, { [FUNCTION_SYNBOL]: Function }>()
 
-  const useStore: UseStore<TState> = <StateSlice>(
+  const useStore: any = <StateSlice>(
     selector: StateSelector<TState, StateSlice> = getState,
     equalityFn: EqualityChecker<StateSlice> = Object.is
   ) => {
@@ -150,7 +155,16 @@ export default function create<TState extends State>(
   const api = { setState, getState, subscribe, destroy }
   state = createState(setState, getState, api)
 
-  return [useStore, api]
+  Object.assign(useStore, api)
+  Object.assign(useStore, { useStore })
+
+  // For backward compatibility (No TS types for this)
+  useStore[Symbol.iterator] = function*() {
+    yield useStore
+    yield api
+  }
+
+  return useStore
 }
 
 export { create }

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -47,21 +47,13 @@ it('creates a store hook and api object', () => {
           "subscribe": [Function],
         },
       ],
-      "result": Array [
-        [Function],
-        Object {
-          "destroy": [Function],
-          "getState": [Function],
-          "setState": [Function],
-          "subscribe": [Function],
-        },
-      ],
+      "result": [Function],
     }
   `)
 })
 
 it('uses the store with no args', async () => {
-  const [useStore] = create(set => ({
+  const useStore = create(set => ({
     count: 0,
     inc: () => set(state => ({ count: state.count + 1 })),
   }))
@@ -78,7 +70,7 @@ it('uses the store with no args', async () => {
 })
 
 it('uses the store with selectors', async () => {
-  const [useStore] = create(set => ({
+  const useStore = create(set => ({
     count: 0,
     inc: () => set(state => ({ count: state.count + 1 })),
   }))
@@ -96,7 +88,8 @@ it('uses the store with selectors', async () => {
 })
 
 it('uses the store with a selector and equality checker', async () => {
-  const [useStore, { setState }] = create(() => ({ value: 0 }))
+  const useStore = create(() => ({ value: 0 }))
+  const { setState } = useStore
   let renderCount = 0
 
   function Component() {
@@ -123,7 +116,7 @@ it('uses the store with a selector and equality checker', async () => {
 })
 
 it('only re-renders if selected state has changed', async () => {
-  const [useStore] = create(set => ({
+  const useStore = create(set => ({
     count: 0,
     inc: () => set(state => ({ count: state.count + 1 })),
   }))
@@ -158,7 +151,7 @@ it('only re-renders if selected state has changed', async () => {
 })
 
 it('can batch updates', async () => {
-  const [useStore] = create(set => ({
+  const useStore = create(set => ({
     count: 0,
     inc: () => set(state => ({ count: state.count + 1 })),
   }))
@@ -180,7 +173,7 @@ it('can batch updates', async () => {
 })
 
 it('can update the selector', async () => {
-  const [useStore] = create(() => ({
+  const useStore = create(() => ({
     one: 'one',
     two: 'two',
   }))
@@ -197,7 +190,8 @@ it('can update the selector', async () => {
 })
 
 it('can update the equality checker', async () => {
-  const [useStore, { setState }] = create(() => ({ value: 0 }))
+  const useStore = create(() => ({ value: 0 }))
+  const { setState } = useStore
   const selector = s => s.value
 
   let renderCount = 0
@@ -226,7 +220,8 @@ it('can update the equality checker', async () => {
 })
 
 it('can call useStore with progressively more arguments', async () => {
-  const [useStore, { setState }] = create(() => ({ value: 0 }))
+  const useStore = create(() => ({ value: 0 }))
+  const { setState } = useStore
 
   let renderCount = 0
   function Component({ selector, equalityFn }: any) {
@@ -266,7 +261,8 @@ it('can throw an error in selector', async () => {
   console.error = jest.fn()
 
   const initialState = { value: 'foo' }
-  const [useStore, { setState }] = create(() => initialState)
+  const useStore = create(() => initialState)
+  const { setState } = useStore
   const selector = s => s.value.toUpperCase()
 
   class ErrorBoundary extends React.Component<any, { hasError: boolean }> {
@@ -302,7 +298,7 @@ it('can throw an error in selector', async () => {
 })
 
 it('can get the store', () => {
-  const [, { getState }] = create((_, get) => ({
+  const { getState } = create((_, get) => ({
     value: 1,
     getState1: () => get(),
     getState2: () => getState(),
@@ -313,7 +309,7 @@ it('can get the store', () => {
 })
 
 it('can set the store', () => {
-  const [, { setState, getState }] = create(set => ({
+  const { setState, getState } = create(set => ({
     value: 1,
     setState1: v => set(v),
     setState2: v => setState(v),
@@ -330,7 +326,7 @@ it('can set the store', () => {
 })
 
 it('can set the store without merging', () => {
-  const [, { setState, getState }] = create(set => ({
+  const { setState, getState } = create(set => ({
     a: 1,
   }))
 
@@ -341,7 +337,7 @@ it('can set the store without merging', () => {
 
 it('can subscribe to the store', () => {
   const initialState = { value: 1, other: 'a' }
-  const [, { setState, getState, subscribe }] = create(() => initialState)
+  const { setState, getState, subscribe } = create(() => initialState)
 
   // Should not be called if new state identity is the same
   let unsub = subscribe(() => {
@@ -401,7 +397,7 @@ it('can subscribe to the store', () => {
 })
 
 it('can destroy the store', () => {
-  const [, { destroy, getState, setState, subscribe }] = create(() => ({
+  const { destroy, getState, setState, subscribe } = create(() => ({
     value: 1,
   }))
 
@@ -415,7 +411,8 @@ it('can destroy the store', () => {
 })
 
 it('only calls selectors when necessary', async () => {
-  const [useStore, { setState }] = create(() => ({ a: 0, b: 0 }))
+  const useStore = create(() => ({ a: 0, b: 0 }))
+  const { setState } = useStore
   let inlineSelectorCallCount = 0
   let callbackSelectorCallCount = 0
   let staticSelectorCallCount = 0
@@ -455,12 +452,13 @@ it('only calls selectors when necessary', async () => {
 })
 
 it('ensures parent components subscribe before children', async () => {
-  const [useStore, api] = create<any>(() => ({
+  const useStore = create<any>(() => ({
     children: {
       '1': { text: 'child 1' },
       '2': { text: 'child 2' },
     },
   }))
+  const api = useStore
 
   function changeState() {
     api.setState({
@@ -496,7 +494,8 @@ it('ensures parent components subscribe before children', async () => {
 
 // https://github.com/react-spring/zustand/issues/84
 it('ensures the correct subscriber is removed on unmount', async () => {
-  const [useStore, api] = create(() => ({ count: 0 }))
+  const useStore = create(() => ({ count: 0 }))
+  const api = useStore
 
   function increment() {
     api.setState(({ count }) => ({ count: count + 1 }))
@@ -538,7 +537,8 @@ it('ensures the correct subscriber is removed on unmount', async () => {
 
 // https://github.com/react-spring/zustand/issues/86
 it('ensures a subscriber is not mistakenly overwritten', async () => {
-  const [useStore, { setState }] = create(() => ({ count: 0 }))
+  const useStore = create(() => ({ count: 0 }))
+  const { setState } = useStore
 
   function Count1() {
     const c = useStore(s => s.count)
@@ -594,7 +594,7 @@ it('can use exposed types', () => {
   const equlaityFn: EqualityChecker<ExampleState> = (state, newState) =>
     state !== newState
 
-  const [useStore, storeApi] = create<ExampleState>((set, get) => ({
+  const storeApi = create<ExampleState>((set, get) => ({
     num: 1,
     numGet: () => get().num,
     numGetState: () => {
@@ -610,6 +610,7 @@ it('can use exposed types', () => {
       storeApi.setState({ num: v })
     },
   }))
+  const useStore = storeApi
 
   const stateCreator: StateCreator<ExampleState> = (set, get) => ({
     num: 1,


### PR DESCRIPTION
Breaking change!!!

before:

```js
const [useStore, api] = create(...)
```

after:

```js
const useStore = create(...)
const api = useStore // if you need
```

OR

```js
const store = create(...)
store.getState()
const value = store.useStore(...)
```