### PR TITLE
[v3] eliminate subscriber + unified api

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 3629,
-    "minified": 1239,
-    "gzipped": 602,
+    "bundled": 3891,
+    "minified": 1391,
+    "gzipped": 692,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 4221,
-    "minified": 1477,
-    "gzipped": 664
+    "bundled": 4910,
+    "minified": 1803,
+    "gzipped": 836
   },
   "dist/index.iife.js": {
-    "bundled": 4444,
-    "minified": 1351,
-    "gzipped": 616
+    "bundled": 5179,
+    "minified": 1677,
+    "gzipped": 787
   },
   "dist/shallow.js": {
     "bundled": 646,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 3934,
-    "minified": 1417,
-    "gzipped": 640,
+    "bundled": 3629,
+    "minified": 1239,
+    "gzipped": 602,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 4638,
-    "minified": 1686,
-    "gzipped": 709
+    "bundled": 4221,
+    "minified": 1477,
+    "gzipped": 664
   },
   "dist/index.iife.js": {
-    "bundled": 4885,
-    "minified": 1560,
-    "gzipped": 658
+    "bundled": 4444,
+    "minified": 1351,
+    "gzipped": 616
   },
   "dist/shallow.js": {
     "bundled": 646,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 3278,
-    "minified": 1121,
-    "gzipped": 570,
+    "bundled": 3934,
+    "minified": 1417,
+    "gzipped": 640,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 3917,
-    "minified": 1378,
-    "gzipped": 642
+    "bundled": 4638,
+    "minified": 1686,
+    "gzipped": 709
   },
   "dist/index.iife.js": {
-    "bundled": 4126,
-    "minified": 1252,
-    "gzipped": 593
+    "bundled": 4885,
+    "minified": 1560,
+    "gzipped": 658
   },
   "dist/shallow.js": {
     "bundled": 646,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,46 +4,44 @@ export type State = Record<string | number | symbol, any>
 export type PartialState<T extends State> =
   | Partial<T>
   | ((state: T) => Partial<T>)
-  | ((state: T) => void)
+  | ((state: T) => void) // for immer https://github.com/react-spring/zustand/pull/99
+export type StateSelector<T extends State, U> = (state: T) => U
+export type EqualityChecker<T> = (state: T, newState: any) => boolean
+
+export type StateListener<T> = (state: T | null, error?: Error) => void
+export type Subscribe<T extends State> = <U>(
+  listener: StateListener<U>,
+  selector?: StateSelector<T, U>,
+  equalityFn?: EqualityChecker<U>
+) => () => void
+export type SetState<T extends State> = (
+  partial: PartialState<T>,
+  replace?: boolean
+) => void
+export type GetState<T extends State> = () => T
+export type Destroy = () => void
+export interface StoreApi<T extends State> {
+  setState: SetState<T>
+  getState: GetState<T>
+  subscribe: Subscribe<T>
+  destroy: Destroy
+}
 export type StateCreator<T extends State> = (
   set: SetState<T>,
   get: GetState<T>,
   api: StoreApi<T>
 ) => T
-export type StateSelector<T extends State, U> = (state: T) => U
-export type StateListener<T> = (state: T | null, error?: Error) => void
-export type SetState<T extends State> = (
-  next: PartialState<T>,
-  replace?: boolean
-) => void
-export type GetState<T extends State> = () => T
-export interface Subscriber<T extends State, U> {
-  currentSlice: U
-  equalityFn: EqualityChecker<U>
-  errored: boolean
-  listener: StateListener<U>
-  selector: StateSelector<T, U>
-  unsubscribe: () => void
-}
-export type Subscribe<T extends State> = <U>(
-  subscriber: Subscriber<T, U>
-) => () => void
-export type ApiSubscribe<T extends State> = <U>(
-  listener: StateListener<U>,
-  selector?: StateSelector<T, U>,
-  equalityFn?: EqualityChecker<U>
-) => () => void
-export type EqualityChecker<T> = (state: T, newState: any) => boolean
-export type Destroy = () => void
+
 export interface UseStore<T extends State> {
   (): T
   <U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): U
-}
-export interface StoreApi<T extends State> {
+  /*
   setState: SetState<T>
   getState: GetState<T>
-  subscribe: ApiSubscribe<T>
+  subscribe: Subscribe<T>
   destroy: Destroy
+  useStore: UseStore<T> // This allows namespace pattern
+  */
 }
 
 // For server-side rendering: https://github.com/react-spring/zustand/pull/34
@@ -56,8 +54,8 @@ export default function create<TState extends State>(
   let state: TState
   let listeners: Set<() => void> = new Set()
 
-  const setState: SetState<TState> = (next, replace) => {
-    const nextState = typeof next === 'function' ? next(state) : next
+  const setState: SetState<TState> = (partial, replace) => {
+    const nextState = typeof partial === 'function' ? partial(state) : partial
 
     if (nextState !== state) {
       if (replace) {
@@ -71,49 +69,31 @@ export default function create<TState extends State>(
 
   const getState: GetState<TState> = () => state
 
-  const getSubscriber = <StateSlice>(
+  const subscribe: Subscribe<TState> = <StateSlice>(
     listener: StateListener<StateSlice>,
     selector: StateSelector<TState, StateSlice> = getState,
     equalityFn: EqualityChecker<StateSlice> = Object.is
-  ): Subscriber<TState, StateSlice> => ({
-    currentSlice: selector(state),
-    equalityFn,
-    errored: false,
-    listener,
-    selector,
-    unsubscribe: () => {},
-  })
-
-  const subscribe: Subscribe<TState> = <StateSlice>(
-    subscriber: Subscriber<TState, StateSlice>
   ) => {
-    function listener() {
+    let currentSlice: StateSlice = selector(state)
+    function listenerToAdd() {
       // Selector or equality function could throw but we don't want to stop
       // the listener from being called.
       // https://github.com/react-spring/zustand/pull/37
       try {
-        const newStateSlice = subscriber.selector(state)
-        if (!subscriber.equalityFn(subscriber.currentSlice, newStateSlice)) {
-          subscriber.listener((subscriber.currentSlice = newStateSlice))
+        const newStateSlice = selector(state)
+        if (!equalityFn(currentSlice, newStateSlice)) {
+          listener((currentSlice = newStateSlice))
         }
       } catch (error) {
-        subscriber.errored = true
-        subscriber.listener(null, error)
+        listener(null, error)
       }
     }
-
-    listeners.add(listener)
-
-    return () => {
-      listeners.delete(listener)
+    listeners.add(listenerToAdd)
+    const unsubscribe = () => {
+      listeners.delete(listenerToAdd)
     }
+    return unsubscribe
   }
-
-  const apiSubscribe: ApiSubscribe<TState> = <StateSlice>(
-    listener: StateListener<StateSlice>,
-    selector?: StateSelector<TState, StateSlice>,
-    equalityFn?: EqualityChecker<StateSlice>
-  ) => subscribe(getSubscriber(listener, selector, equalityFn))
 
   const destroy: Destroy = () => listeners.clear()
 
@@ -152,7 +132,7 @@ export default function create<TState extends State>(
         }
         forceUpdate(undefined)
       }
-      subscriberRef.current.unsubscribe = apiSubscribe(
+      subscriberRef.current.unsubscribe = subscribe(
         subscriber.listener,
         subscriber.selector,
         subscriber.equalityFn
@@ -189,7 +169,7 @@ export default function create<TState extends State>(
         subscriber.unsubscribe()
         subscriber.selector = selector
         subscriber.equalityFn = equalityFn
-        subscriber.unsubscribe = apiSubscribe(
+        subscriber.unsubscribe = subscribe(
           subscriber.listener,
           subscriber.selector,
           subscriber.equalityFn
@@ -204,7 +184,7 @@ export default function create<TState extends State>(
       : subscriber.currentSlice
   }
 
-  const api = { setState, getState, subscribe: apiSubscribe, destroy }
+  const api = { setState, getState, subscribe, destroy }
   state = createState(setState, getState, api)
 
   return [useStore, api]

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -13,11 +13,10 @@ import create, {
   StateSelector,
   PartialState,
   EqualityChecker,
-  Subscriber,
   StateCreator,
   SetState,
   GetState,
-  ApiSubscribe,
+  Subscribe,
   Destroy,
   UseStore,
   StoreApi,
@@ -477,16 +476,16 @@ it('only calls selectors when necessary', async () => {
   }
 
   const { rerender, getByText } = render(<Component />)
-  await waitForElement(() => getByText('inline: 1'))
-  await waitForElement(() => getByText('static: 1'))
+  await waitForElement(() => getByText('inline: 2'))
+  await waitForElement(() => getByText('static: 2'))
 
   rerender(<Component />)
-  await waitForElement(() => getByText('inline: 2'))
-  await waitForElement(() => getByText('static: 1'))
+  await waitForElement(() => getByText('inline: 3'))
+  await waitForElement(() => getByText('static: 2'))
 
   act(() => setState({ a: 1, b: 1 }))
-  await waitForElement(() => getByText('inline: 4'))
-  await waitForElement(() => getByText('static: 2'))
+  await waitForElement(() => getByText('inline: 6'))
+  await waitForElement(() => getByText('static: 3'))
 })
 
 it('ensures parent components subscribe before children', async () => {
@@ -658,15 +657,6 @@ it('can use exposed types', () => {
     },
   })
 
-  const subscriber: Subscriber<ExampleState, number> = {
-    currentSlice: 1,
-    equalityFn: Object.is,
-    errored: false,
-    listener(n: number | null) {},
-    selector,
-    unsubscribe: () => {},
-  }
-
   function checkAllTypes(
     getState: GetState<ExampleState>,
     partialState: PartialState<ExampleState>,
@@ -675,12 +665,11 @@ it('can use exposed types', () => {
     stateListener: StateListener<ExampleState>,
     stateSelector: StateSelector<ExampleState, number>,
     storeApi: StoreApi<ExampleState>,
-    subscribe: ApiSubscribe<ExampleState>,
+    subscribe: Subscribe<ExampleState>,
     destroy: Destroy,
     equalityFn: EqualityChecker<ExampleState>,
     stateCreator: StateCreator<ExampleState>,
-    useStore: UseStore<ExampleState>,
-    subscribeOptions: Subscriber<ExampleState, number>
+    useStore: UseStore<ExampleState>
   ) {
     expect(true).toBeTruthy()
   }
@@ -697,7 +686,6 @@ it('can use exposed types', () => {
     storeApi.destroy,
     equlaityFn,
     stateCreator,
-    useStore,
-    subscriber
+    useStore
   )
 })

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -47,21 +47,13 @@ it('creates a store hook and api object', () => {
           "subscribe": [Function],
         },
       ],
-      "result": Array [
-        [Function],
-        Object {
-          "destroy": [Function],
-          "getState": [Function],
-          "setState": [Function],
-          "subscribe": [Function],
-        },
-      ],
+      "result": [Function],
     }
   `)
 })
 
 it('uses the store with no args', async () => {
-  const [useStore] = create(set => ({
+  const useStore = create(set => ({
     count: 0,
     inc: () => set(state => ({ count: state.count + 1 })),
   }))
@@ -78,7 +70,7 @@ it('uses the store with no args', async () => {
 })
 
 it('uses the store with selectors', async () => {
-  const [useStore] = create(set => ({
+  const useStore = create(set => ({
     count: 0,
     inc: () => set(state => ({ count: state.count + 1 })),
   }))
@@ -96,7 +88,8 @@ it('uses the store with selectors', async () => {
 })
 
 it('uses the store with a selector and equality checker', async () => {
-  const [useStore, { setState }] = create(() => ({ value: 0 }))
+  const useStore = create(() => ({ value: 0 }))
+  const { setState } = useStore
   let renderCount = 0
 
   function Component() {
@@ -123,7 +116,7 @@ it('uses the store with a selector and equality checker', async () => {
 })
 
 it('only re-renders if selected state has changed', async () => {
-  const [useStore] = create(set => ({
+  const useStore = create(set => ({
     count: 0,
     inc: () => set(state => ({ count: state.count + 1 })),
   }))
@@ -158,7 +151,7 @@ it('only re-renders if selected state has changed', async () => {
 })
 
 it('can batch updates', async () => {
-  const [useStore] = create(set => ({
+  const useStore = create(set => ({
     count: 0,
     inc: () => set(state => ({ count: state.count + 1 })),
   }))
@@ -180,7 +173,7 @@ it('can batch updates', async () => {
 })
 
 it('can update the selector', async () => {
-  const [useStore] = create(() => ({
+  const useStore = create(() => ({
     one: 'one',
     two: 'two',
   }))
@@ -197,7 +190,8 @@ it('can update the selector', async () => {
 })
 
 it('can update the equality checker', async () => {
-  const [useStore, { setState }] = create(() => ({ value: 0 }))
+  const useStore = create(() => ({ value: 0 }))
+  const { setState } = useStore
   const selector = s => s.value
 
   let renderCount = 0
@@ -226,7 +220,8 @@ it('can update the equality checker', async () => {
 })
 
 it('can call useStore with progressively more arguments', async () => {
-  const [useStore, { setState }] = create(() => ({ value: 0 }))
+  const useStore = create(() => ({ value: 0 }))
+  const { setState } = useStore
 
   let renderCount = 0
   function Component({ selector, equalityFn }: any) {
@@ -266,7 +261,8 @@ it('can throw an error in selector', async () => {
   console.error = jest.fn()
 
   const initialState = { value: 'foo' }
-  const [useStore, { setState }] = create(() => initialState)
+  const useStore = create(() => initialState)
+  const { setState } = useStore
   const selector = s => s.value.toUpperCase()
 
   class ErrorBoundary extends React.Component<any, { hasError: boolean }> {
@@ -305,7 +301,8 @@ it('can throw an error in equality checker', async () => {
   console.error = jest.fn()
 
   const initialState = { value: 'foo' }
-  const [useStore, { setState }] = create(() => initialState)
+  const useStore = create(() => initialState)
+  const { setState } = useStore
   const selector = s => s
   const equalityFn = (a, b) => a.value.trim() === b.value.trim()
 
@@ -342,7 +339,7 @@ it('can throw an error in equality checker', async () => {
 })
 
 it('can get the store', () => {
-  const [, { getState }] = create((_, get) => ({
+  const { getState } = create((_, get) => ({
     value: 1,
     getState1: () => get(),
     getState2: () => getState(),
@@ -353,7 +350,7 @@ it('can get the store', () => {
 })
 
 it('can set the store', () => {
-  const [, { setState, getState }] = create(set => ({
+  const { setState, getState } = create(set => ({
     value: 1,
     setState1: v => set(v),
     setState2: v => setState(v),
@@ -370,7 +367,7 @@ it('can set the store', () => {
 })
 
 it('can set the store without merging', () => {
-  const [, { setState, getState }] = create(set => ({
+  const { setState, getState } = create(set => ({
     a: 1,
   }))
 
@@ -381,7 +378,7 @@ it('can set the store without merging', () => {
 
 it('can subscribe to the store', () => {
   const initialState = { value: 1, other: 'a' }
-  const [, { setState, getState, subscribe }] = create(() => initialState)
+  const { setState, getState, subscribe } = create(() => initialState)
 
   // Should not be called if new state identity is the same
   let unsub = subscribe(() => {
@@ -441,7 +438,7 @@ it('can subscribe to the store', () => {
 })
 
 it('can destroy the store', () => {
-  const [, { destroy, getState, setState, subscribe }] = create(() => ({
+  const { destroy, getState, setState, subscribe } = create(() => ({
     value: 1,
   }))
 
@@ -455,7 +452,8 @@ it('can destroy the store', () => {
 })
 
 it('only calls selectors when necessary', async () => {
-  const [useStore, { setState }] = create(() => ({ a: 0, b: 0 }))
+  const useStore = create(() => ({ a: 0, b: 0 }))
+  const { setState } = useStore
   let inlineSelectorCallCount = 0
   let staticSelectorCallCount = 0
 
@@ -489,12 +487,13 @@ it('only calls selectors when necessary', async () => {
 })
 
 it('ensures parent components subscribe before children', async () => {
-  const [useStore, api] = create<any>(() => ({
+  const useStore = create<any>(() => ({
     children: {
       '1': { text: 'child 1' },
       '2': { text: 'child 2' },
     },
   }))
+  const api = useStore
 
   function changeState() {
     api.setState({
@@ -530,7 +529,8 @@ it('ensures parent components subscribe before children', async () => {
 
 // https://github.com/react-spring/zustand/issues/84
 it('ensures the correct subscriber is removed on unmount', async () => {
-  const [useStore, api] = create(() => ({ count: 0 }))
+  const useStore = create(() => ({ count: 0 }))
+  const api = useStore
 
   function increment() {
     api.setState(({ count }) => ({ count: count + 1 }))
@@ -572,7 +572,8 @@ it('ensures the correct subscriber is removed on unmount', async () => {
 
 // https://github.com/react-spring/zustand/issues/86
 it('ensures a subscriber is not mistakenly overwritten', async () => {
-  const [useStore, { setState }] = create(() => ({ count: 0 }))
+  const useStore = create(() => ({ count: 0 }))
+  const { setState } = useStore
 
   function Count1() {
     const c = useStore(s => s.count)
@@ -628,7 +629,7 @@ it('can use exposed types', () => {
   const equlaityFn: EqualityChecker<ExampleState> = (state, newState) =>
     state !== newState
 
-  const [useStore, storeApi] = create<ExampleState>((set, get) => ({
+  const storeApi = create<ExampleState>((set, get) => ({
     num: 1,
     numGet: () => get().num,
     numGetState: () => {
@@ -644,6 +645,7 @@ it('can use exposed types', () => {
       storeApi.setState({ num: v })
     },
   }))
+  const useStore = storeApi
 
   const stateCreator: StateCreator<ExampleState> = (set, get) => ({
     num: 1,


### PR DESCRIPTION
- eliminate subscriber so that we can extract vanilla version
- unified api with backward compatible tuple (no type)

Important notes:
- It will call selector once more at subscribe due to caching at the both ends
  - This is a bit unfortunate, but it's more consistent with v4-alpha
- The use of `useCallback` for selector and equalityFn is highly recommended
  - Or define the function outside render
  - It will be optimized with ref equality
  - This is also the case with v4-alpha
  - Without `useCallback`, it will still work, can be slow but not noticable in small apps.