### PR TITLE
[v3] add slim subscribe and refactor useStore

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 3116,
-    "minified": 1132,
-    "gzipped": 600,
+    "bundled": 3092,
+    "minified": 1066,
+    "gzipped": 568,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 3974,
-    "minified": 1499,
-    "gzipped": 728
+    "bundled": 3940,
+    "minified": 1451,
+    "gzipped": 697
   },
   "dist/index.iife.js": {
-    "bundled": 4197,
-    "minified": 1373,
-    "gzipped": 686
+    "bundled": 4157,
+    "minified": 1313,
+    "gzipped": 652
   },
   "dist/shallow.js": {
     "bundled": 646,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 3234,
-    "minified": 1228,
-    "gzipped": 637,
+    "bundled": 3116,
+    "minified": 1132,
+    "gzipped": 600,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 4148,
-    "minified": 1612,
-    "gzipped": 772
+    "bundled": 3974,
+    "minified": 1499,
+    "gzipped": 728
   },
   "dist/index.iife.js": {
-    "bundled": 4377,
-    "minified": 1486,
-    "gzipped": 730
+    "bundled": 4197,
+    "minified": 1373,
+    "gzipped": 686
   },
   "dist/shallow.js": {
     "bundled": 646,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 3891,
-    "minified": 1391,
-    "gzipped": 692,
+    "bundled": 3234,
+    "minified": 1228,
+    "gzipped": 637,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 4910,
-    "minified": 1803,
-    "gzipped": 836
+    "bundled": 4148,
+    "minified": 1612,
+    "gzipped": 772
   },
   "dist/index.iife.js": {
-    "bundled": 5179,
-    "minified": 1677,
-    "gzipped": 787
+    "bundled": 4377,
+    "minified": 1486,
+    "gzipped": 730
   },
   "dist/shallow.js": {
     "bundled": 646,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.js": {
-    "bundled": 3094,
-    "minified": 1066,
-    "gzipped": 568,
+    "bundled": 3957,
+    "minified": 1227,
+    "gzipped": 631,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -14,14 +14,14 @@
     }
   },
   "dist/index.cjs.js": {
-    "bundled": 3940,
-    "minified": 1451,
-    "gzipped": 697
+    "bundled": 4951,
+    "minified": 1652,
+    "gzipped": 762
   },
   "dist/index.iife.js": {
-    "bundled": 4157,
-    "minified": 1313,
-    "gzipped": 652
+    "bundled": 5228,
+    "minified": 1514,
+    "gzipped": 718
   },
   "dist/shallow.js": {
     "bundled": 646,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "dist/index.js": {
-    "bundled": 3092,
+    "bundled": 3094,
     "minified": 1066,
     "gzipped": 568,
     "treeshaked": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export default function create<TState extends State>(
   createState: StateCreator<TState>
 ): UseStore<TState> {
   let state: TState
-  let listeners: Set<StateListener<TState>> = new Set()
+  const listeners: Set<StateListener<TState>> = new Set()
 
   const setState: SetState<TState> = (partial, replace) => {
     const nextState = typeof partial === 'function' ? partial(state) : partial

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -393,6 +393,48 @@ it('can subscribe to the store', () => {
   })
   setState({ ...getState() })
   unsub()
+
+  // Should not be called when state slice is the same
+  unsub = subscribe(
+    () => {
+      throw new Error('subscriber called when new state is the same')
+    },
+    s => s.value
+  )
+  setState({ other: 'b' })
+  unsub()
+
+  // Should be called when state slice changes
+  unsub = subscribe(
+    (value: number | null) => {
+      expect(value).toBe(initialState.value + 1)
+    },
+    s => s.value
+  )
+  setState({ value: initialState.value + 1 })
+  unsub()
+
+  // Should not be called when equality checker returns true
+  unsub = subscribe(
+    () => {
+      throw new Error('subscriber called when equality checker returned true')
+    },
+    undefined,
+    () => true
+  )
+  setState({ value: initialState.value + 2 })
+  unsub()
+
+  // Should be called when equality checker returns false
+  unsub = subscribe(
+    (value: number | null) => {
+      expect(value).toBe(initialState.value + 2)
+    },
+    s => s.value,
+    () => false
+  )
+  setState(getState())
+  unsub()
 })
 
 it('can destroy the store', () => {

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -393,48 +393,6 @@ it('can subscribe to the store', () => {
   })
   setState({ ...getState() })
   unsub()
-
-  // Should not be called when state slice is the same
-  unsub = subscribe(
-    () => {
-      throw new Error('subscriber called when new state is the same')
-    },
-    s => s.value
-  )
-  setState({ other: 'b' })
-  unsub()
-
-  // Should be called when state slice changes
-  unsub = subscribe(
-    (value: number | null) => {
-      expect(value).toBe(initialState.value + 1)
-    },
-    s => s.value
-  )
-  setState({ value: initialState.value + 1 })
-  unsub()
-
-  // Should not be called when equality checker returns true
-  unsub = subscribe(
-    () => {
-      throw new Error('subscriber called when equality checker returned true')
-    },
-    undefined,
-    () => true
-  )
-  setState({ value: initialState.value + 2 })
-  unsub()
-
-  // Should be called when equality checker returns false
-  unsub = subscribe(
-    (value: number | null) => {
-      expect(value).toBe(initialState.value + 2)
-    },
-    s => s.value,
-    () => false
-  )
-  setState(getState())
-  unsub()
 })
 
 it('can destroy the store', () => {
@@ -474,16 +432,16 @@ it('only calls selectors when necessary', async () => {
   }
 
   const { rerender, getByText } = render(<Component />)
-  await waitForElement(() => getByText('inline: 2'))
-  await waitForElement(() => getByText('static: 2'))
+  await waitForElement(() => getByText('inline: 1'))
+  await waitForElement(() => getByText('static: 1'))
 
   rerender(<Component />)
-  await waitForElement(() => getByText('inline: 3'))
-  await waitForElement(() => getByText('static: 2'))
+  await waitForElement(() => getByText('inline: 2'))
+  await waitForElement(() => getByText('static: 1'))
 
   act(() => setState({ a: 1, b: 1 }))
-  await waitForElement(() => getByText('inline: 6'))
-  await waitForElement(() => getByText('static: 3'))
+  await waitForElement(() => getByText('inline: 4'))
+  await waitForElement(() => getByText('static: 2'))
 })
 
 it('ensures parent components subscribe before children', async () => {


### PR DESCRIPTION
This will refactor subscribe and clean up code quite a bit.

This is technically a breaking change. Exported types are a bit changed.

----

#139 
> It will call selector once more at subscribe due to caching at the both ends

This hack is gone. See the test spec is reverted.

#114
> We could revisit this in v3

Because, we don't have selector in subscribe. No throwing error. Cleaner listener typing.