### PR TITLE
Uses prefix as devtools instance name

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -38,7 +38,7 @@ const devtools = (fn: any, prefix?: string) => (
   }
   const initialState = fn(namedSet, get, api)
   if (!api.devtools) {
-    api.devtools = extension.connect()
+    api.devtools = extension.connect({ name: prefix })
     api.devtools.prefix = prefix ? `${prefix} > ` : ''
     api.devtools.subscribe((message: any) => {
       if (message.type === 'DISPATCH' && message.state) {


### PR DESCRIPTION
If a prefix is provided, it will be used as the instance name. If one is not provided, the default devtools behaviour will be used.