### PR TITLE
fix: detect state change before subscription

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -39,9 +39,9 @@
     "gzipped": 354
   },
   "index.js": {
-    "bundled": 3974,
-    "minified": 1304,
-    "gzipped": 642,
+    "bundled": 4173,
+    "minified": 1360,
+    "gzipped": 672,
     "treeshaked": {
       "rollup": {
         "code": 14,
@@ -53,14 +53,14 @@
     }
   },
   "index.cjs.js": {
-    "bundled": 5287,
-    "minified": 2019,
-    "gzipped": 859
+    "bundled": 5494,
+    "minified": 2072,
+    "gzipped": 886
   },
   "index.iife.js": {
-    "bundled": 5530,
-    "minified": 1695,
-    "gzipped": 763
+    "bundled": 5747,
+    "minified": 1757,
+    "gzipped": 795
   },
   "shallow.js": {
     "bundled": 644,


### PR DESCRIPTION
There's an edge case where state is changed between when a hook is used in the render phase and when a hook subscribes to a store in the commit phase.