### PR TITLE
fix devtools and type middleware properly

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -68,9 +68,9 @@
     "gzipped": 251
   },
   "middleware.js": {
-    "bundled": 2039,
-    "minified": 1207,
-    "gzipped": 610
+    "bundled": 2088,
+    "minified": 1231,
+    "gzipped": 628
   },
   "vanilla.js": {
     "bundled": 1990,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,21 +1,42 @@
-const redux = (reducer: any, initial: any) => (
-  set: any,
-  get: any,
-  api: any
-) => {
-  api.dispatch = (action: any) => {
-    set((state: any) => reducer(state, action))
+import type {
+  State,
+  GetState,
+  SetState,
+  StoreApi,
+  PartialState,
+} from './vanilla'
+
+const redux = <S extends State, A extends { type: unknown }>(
+  reducer: (state: S, action: A) => S,
+  initial: S
+) => (
+  set: SetState<S & { dispatch: (a: A) => A }>,
+  get: GetState<S & { dispatch: (a: A) => A }>,
+  api: StoreApi<S & { dispatch: (a: A) => A }> & {
+    dispatch?: (a: A) => A
+    devtools?: any
+  }
+): S & { dispatch: (a: A) => A } => {
+  api.dispatch = (action: A) => {
+    set((state: S) => reducer(state, action))
     api.devtools && api.devtools.send(api.devtools.prefix + action.type, get())
     return action
   }
   return { dispatch: api.dispatch, ...initial }
 }
 
-const devtools = (fn: any, prefix?: string) => (
-  set: any,
-  get: any,
-  api: any
-) => {
+const devtools = <S extends State>(
+  fn: (
+    set: (partial: PartialState<S>, replace?: boolean, name?: string) => void,
+    get: GetState<S>,
+    api: StoreApi<S>
+  ) => S,
+  prefix?: string
+) => (
+  set: SetState<S>,
+  get: GetState<S>,
+  api: StoreApi<S> & { devtools?: any }
+): S => {
   let extension
   try {
     extension =
@@ -30,10 +51,14 @@ const devtools = (fn: any, prefix?: string) => (
     api.devtools = null
     return fn(set, get, api)
   }
-  const namedSet = (state: any, name?: any) => {
-    set(state)
-    if (name) {
-      api.devtools.send(api.devtools.prefix + name, get())
+  const namedSet = (
+    state: PartialState<S>,
+    replace?: boolean,
+    name?: string | false
+  ) => {
+    set(state, replace)
+    if (name !== false) {
+      api.devtools.send(api.devtools.prefix + (name || 'action'), get())
     }
   }
   const initialState = fn(namedSet, get, api)
@@ -47,6 +72,7 @@ const devtools = (fn: any, prefix?: string) => (
           message.payload.type === 'JUMP_TO_STATE'
         namedSet(
           JSON.parse(message.state),
+          false,
           !initialState.dispatch && !ignoreState && 'setState'
         )
       }


### PR DESCRIPTION
Close #77 

- devtools follows v3 api (`replace` flag)
- devtools works without `name` (defaults to `action`)
- type devtools and redux middleware (a bit messy, can improve?)

Here's how you could use devtools in TS.

```ts
const useStore = create<{
  count: number
  increment: () => void
  decrement: () => void
}>(devtools((set, get) => ({
  count: 0,
  increment: () => set({ count: get().count + 1 }, false, "inc"),
  decrement: () => set({ count: get().count - 1 }, false, "dec"),
})));
```

Here's redux middleware in TS.

```ts
const initialState = {                                                          
  grumpiness: 0,                                                                
}                                                                             
                                                                              
const reducer = (  
  state: typeof initialState,  
  action: { type: "INCREASE" | "DECREASE", by: number }                
) => {                                                                          
  switch (action.type) {                                                        
    case "INCREASE": return { grumpiness: state.grumpiness + action.by }        
    case "DECREASE": return { grumpiness: state.grumpiness - action.by }        
    default: return state                                                       
  }                                                                             
}                                                                               
                                                                                
const useReduxStore = create(devtools(redux(reducer, initialState)))            
```