### PR TITLE
fix typing for immer

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -1,9 +1,7 @@
 export type State = Record<string | number | symbol, any>
-// (state: T) => void is for immer https://github.com/react-spring/zustand/pull/99
 export type PartialState<T extends State> =
   | Partial<T>
   | ((state: T) => Partial<T>)
-  | ((state: T) => void)
 export type StateSelector<T extends State, U> = (state: T) => U
 export type EqualityChecker<T> = (state: T, newState: any) => boolean
 export type StateListener<T> = (state: T) => void
@@ -28,8 +26,8 @@ export interface StoreApi<T extends State> {
   subscribe: Subscribe<T>
   destroy: Destroy
 }
-export type StateCreator<T extends State> = (
-  set: SetState<T>,
+export type StateCreator<T extends State, CustomSetState = SetState<T>> = (
+  set: CustomSetState,
   get: GetState<T>,
   api: StoreApi<T>
 ) => T


### PR DESCRIPTION
Close #96 

The fix in #99 doesn't seem correct. https://github.com/react-spring/zustand/issues/96#issuecomment-673764960

This would be a better fix. Although this reverts #99, I couldn't get response in #96, so let's publish it and see how it works.

Here's immer recipe in TS without middleware.

```ts
interface State {
  lush: {
    forrest: {
      contains: { a: string } | null
    }
  }
  set: (fn: (s: State) => void) => void
}

const useStore = create<State>((set) => ({
  lush: { forrest: { contains: { a: "bear" } } },
  set: (fn) => set(produce(fn)),
}))

const a = useStore((state) => state.lush.forrest.contains?.a)
const set = useStore((state) => state.set)
set(state => {
  state.lush.forrest.contains = null
})
```

Here's the recipe with middleware.

```ts
connst immer = <T>(
  config: StateCreator<T, (fn: (state: T) => void) => void>
): StateCreator<T> => (set, get, api) => config(
  (fn) => set(produce(fn) as (state: T) => T),
  get,
  api
)

const useStore = create<{
  bees: boolean
  setBees: (b: boolean) => void
}>(
  immer((set) => ({
    bees: false,
    setBees: (input) =>
      set((state) => {
        state.bees = input
      }),
  }))
)
```