### PR TITLE
fix: devtools to patch api.setState

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -68,9 +68,9 @@
     "gzipped": 251
   },
   "middleware.js": {
-    "bundled": 2381,
-    "minified": 1359,
-    "gzipped": 644
+    "bundled": 2409,
+    "minified": 1355,
+    "gzipped": 641
   },
   "vanilla.js": {
     "bundled": 1990,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -68,9 +68,9 @@
     "gzipped": 251
   },
   "middleware.js": {
-    "bundled": 2168,
-    "minified": 1257,
-    "gzipped": 637
+    "bundled": 2352,
+    "minified": 1347,
+    "gzipped": 642
   },
   "vanilla.js": {
     "bundled": 1990,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -68,9 +68,9 @@
     "gzipped": 251
   },
   "middleware.js": {
-    "bundled": 2352,
-    "minified": 1347,
-    "gzipped": 642
+    "bundled": 2381,
+    "minified": 1359,
+    "gzipped": 644
   },
   "vanilla.js": {
     "bundled": 1990,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -68,9 +68,9 @@
     "gzipped": 251
   },
   "middleware.js": {
-    "bundled": 2088,
-    "minified": 1231,
-    "gzipped": 628
+    "bundled": 2168,
+    "minified": 1257,
+    "gzipped": 637
   },
   "vanilla.js": {
     "bundled": 1990,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -68,9 +68,9 @@
     "gzipped": 251
   },
   "middleware.js": {
-    "bundled": 2409,
-    "minified": 1355,
-    "gzipped": 641
+    "bundled": 2381,
+    "minified": 1359,
+    "gzipped": 644
   },
   "vanilla.js": {
     "bundled": 1990,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -68,7 +68,7 @@
     "gzipped": 251
   },
   "middleware.js": {
-    "bundled": 2381,
+    "bundled": 2403,
     "minified": 1359,
     "gzipped": 644
   },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,9 +19,8 @@ const redux = <S extends State, A extends { type: unknown }>(
 ): S & { dispatch: (a: A) => A } => {
   api.dispatch = (action: A) => {
     api.setState((state: S) => reducer(state, action))
-    if (api.devtools) {
+    api.devtools &&
       api.devtools.send(api.devtools.prefix + action.type, api.getState())
-    }
     return action
   }
   return { dispatch: api.dispatch, ...initial }
@@ -64,9 +63,7 @@ const devtools = <S extends State>(
     const savedSetState = api.setState
     api.setState = (state: PartialState<S>, replace?: boolean) => {
       savedSetState(state, replace)
-      if (!api.dispatch) {
-        api.devtools.send(api.devtools.prefix + 'setState', api.getState())
-      }
+      api.devtools.send(api.devtools.prefix + 'setState', api.getState())
     }
     api.devtools = extension.connect({ name: prefix })
     api.devtools.prefix = prefix ? `${prefix} > ` : ''
@@ -75,10 +72,10 @@ const devtools = <S extends State>(
         const ignoreState =
           message.payload.type === 'JUMP_TO_ACTION' ||
           message.payload.type === 'JUMP_TO_STATE'
-        if (ignoreState) {
-          savedSetState(JSON.parse(message.state))
-        } else {
+        if (!api.dispatch && !ignoreState) {
           api.setState(JSON.parse(message.state))
+        } else {
+          savedSetState(JSON.parse(message.state))
         }
       }
     })

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,16 +10,18 @@ const redux = <S extends State, A extends { type: unknown }>(
   reducer: (state: S, action: A) => S,
   initial: S
 ) => (
-  set: SetState<S & { dispatch: (a: A) => A }>,
-  get: GetState<S & { dispatch: (a: A) => A }>,
-  api: StoreApi<S & { dispatch: (a: A) => A }> & {
+  set: SetState<S>,
+  get: GetState<S>,
+  api: StoreApi<S> & {
     dispatch?: (a: A) => A
     devtools?: any
   }
 ): S & { dispatch: (a: A) => A } => {
   api.dispatch = (action: A) => {
     set((state: S) => reducer(state, action))
-    api.devtools && api.devtools.send(api.devtools.prefix + action.type, get())
+    if (api.devtools) {
+      api.devtools.send(api.devtools.prefix + action.type, get())
+    }
     return action
   }
   return { dispatch: api.dispatch, ...initial }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -37,7 +37,7 @@ const devtools = <S extends State>(
 ) => (
   set: SetState<S>,
   get: GetState<S>,
-  api: StoreApi<S> & { devtools?: any }
+  api: StoreApi<S> & { dispatch?: unknown; devtools?: any }
 ): S => {
   let extension
   try {
@@ -55,7 +55,9 @@ const devtools = <S extends State>(
   }
   const namedSet: NamedSet<S> = (state, replace, name) => {
     set(state, replace)
-    api.devtools.send(api.devtools.prefix + (name || 'action'), get())
+    if (!api.dispatch) {
+      api.devtools.send(api.devtools.prefix + (name || 'action'), get())
+    }
   }
   const initialState = fn(namedSet, get, api)
   if (!api.devtools) {
@@ -71,7 +73,7 @@ const devtools = <S extends State>(
         const ignoreState =
           message.payload.type === 'JUMP_TO_ACTION' ||
           message.payload.type === 'JUMP_TO_STATE'
-        if (!initialState.dispatch && !ignoreState) {
+        if (!api.dispatch && !ignoreState) {
           api.setState(JSON.parse(message.state))
         } else {
           savedSetState(JSON.parse(message.state))

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,16 +10,17 @@ const redux = <S extends State, A extends { type: unknown }>(
   reducer: (state: S, action: A) => S,
   initial: S
 ) => (
-  set: SetState<S & { dispatch: (a: A) => A }>,
-  get: GetState<S & { dispatch: (a: A) => A }>,
-  api: StoreApi<S & { dispatch: (a: A) => A }> & {
+  _set: unknown,
+  _get: unknown,
+  api: StoreApi<S> & {
     dispatch?: (a: A) => A
     devtools?: any
   }
 ): S & { dispatch: (a: A) => A } => {
   api.dispatch = (action: A) => {
-    set((state: S) => reducer(state, action))
-    api.devtools && api.devtools.send(api.devtools.prefix + action.type, get())
+    api.setState((state: S) => reducer(state, action))
+    api.devtools &&
+      api.devtools.send(api.devtools.prefix + action.type, api.getState())
     return action
   }
   return { dispatch: api.dispatch, ...initial }
@@ -55,9 +56,7 @@ const devtools = <S extends State>(
   }
   const namedSet: NamedSet<S> = (state, replace, name) => {
     set(state, replace)
-    if (!api.dispatch) {
-      api.devtools.send(api.devtools.prefix + (name || 'action'), get())
-    }
+    api.devtools.send(api.devtools.prefix + (name || 'action'), get())
   }
   const initialState = fn(namedSet, get, api)
   if (!api.devtools) {


### PR DESCRIPTION
Close #171. 

~There are a few technical issues:~
~1. we need to fix types in vanilla.ts and index.ts too.~
~2. we can't chain middleware that only patches `set`.~

~Due to 2), I'm a bit hesitant to this approach.~