### PR TITLE
Stricter types

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -68,9 +68,9 @@
     "gzipped": 251
   },
   "middleware.js": {
-    "bundled": 2403,
-    "minified": 1359,
-    "gzipped": 644
+    "bundled": 2599,
+    "minified": 1469,
+    "gzipped": 676
   },
   "vanilla.js": {
     "bundled": 1990,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -68,9 +68,9 @@
     "gzipped": 251
   },
   "middleware.js": {
-    "bundled": 2599,
-    "minified": 1469,
-    "gzipped": 676
+    "bundled": 2631,
+    "minified": 1493,
+    "gzipped": 680
   },
   "vanilla.js": {
     "bundled": 1990,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -68,9 +68,9 @@
     "gzipped": 251
   },
   "middleware.js": {
-    "bundled": 2631,
-    "minified": 1493,
-    "gzipped": 680
+    "bundled": 2595,
+    "minified": 1466,
+    "gzipped": 677
   },
   "vanilla.js": {
     "bundled": 1990,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { useEffect, useLayoutEffect, useReducer, useRef } from 'react'
-export * from './vanilla'
 import createImpl, {
   Destroy,
   EqualityChecker,
@@ -11,6 +10,7 @@ import createImpl, {
   Subscribe,
   StoreApi,
 } from './vanilla'
+export * from './vanilla'
 
 // For server-side rendering: https://github.com/react-spring/zustand/pull/34
 const useIsoLayoutEffect =

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export default function create<TState extends State>(
     typeof createState === 'function' ? createImpl(createState) : createState
 
   const useStore: any = <StateSlice>(
-    selector: StateSelector<TState, StateSlice> = api.getState,
+    selector: StateSelector<TState, StateSlice> = api.getState as any,
     equalityFn: EqualityChecker<StateSlice> = Object.is
   ) => {
     const forceUpdate = useReducer((c) => c + 1, 0)[1] as () => void

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,4 @@
-import type {
+import {
   State,
   GetState,
   SetState,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -88,7 +88,7 @@ export const devtools = <S extends State>(
   return initialState
 }
 
-export const createPS = <
+export const withInitialState = <
   PrimaryState extends State,
   SecondaryState extends State
 >(

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -88,7 +88,7 @@ export const devtools = <S extends State>(
   return initialState
 }
 
-export const withInitialState = <
+export const combine = <
   PrimaryState extends State,
   SecondaryState extends State
 >(

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,9 +4,10 @@ import type {
   SetState,
   StoreApi,
   PartialState,
+  StateCreator,
 } from './vanilla'
 
-const redux = <S extends State, A extends { type: unknown }>(
+export const redux = <S extends State, A extends { type: unknown }>(
   reducer: (state: S, action: A) => S,
   initial: S
 ) => (
@@ -27,13 +28,13 @@ const redux = <S extends State, A extends { type: unknown }>(
   return { dispatch: api.dispatch, ...initial }
 }
 
-type NamedSet<S> = (
+type NamedSet<S extends State> = (
   partial: PartialState<S>,
   replace?: boolean,
   name?: string
 ) => void
 
-const devtools = <S extends State>(
+export const devtools = <S extends State>(
   fn: (set: NamedSet<S>, get: GetState<S>, api: StoreApi<S>) => S,
   prefix?: string
 ) => (
@@ -87,4 +88,23 @@ const devtools = <S extends State>(
   return initialState
 }
 
-export { devtools, redux }
+export const createPS = <
+  PrimaryState extends State,
+  SecondaryState extends State
+>(
+  initialState: PrimaryState,
+  create: (
+    set: SetState<PrimaryState>,
+    get: GetState<PrimaryState>,
+    api: StoreApi<PrimaryState>
+  ) => SecondaryState
+): StateCreator<PrimaryState & SecondaryState> => (set, get, api) =>
+  Object.assign(
+    {},
+    initialState,
+    create(
+      set as SetState<PrimaryState>,
+      get as GetState<PrimaryState>,
+      api as StoreApi<PrimaryState>
+    )
+  )

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -1,9 +1,9 @@
-export type State = Record<string | number | symbol, any>
+export type State = Record<string | number | symbol, unknown>
 export type PartialState<T extends State> =
   | Partial<T>
   | ((state: T) => Partial<T>)
 export type StateSelector<T extends State, U> = (state: T) => U
-export type EqualityChecker<T> = (state: T, newState: any) => boolean
+export type EqualityChecker<T> = (state: T, newState: unknown) => boolean
 export type StateListener<T> = (state: T) => void
 export type StateSliceListener<T> = (state: T | null, error?: Error) => void
 export interface Subscribe<T extends State> {
@@ -36,7 +36,7 @@ export default function create<TState extends State>(
   createState: StateCreator<TState>
 ): StoreApi<TState> {
   let state: TState
-  const listeners: Set<(s: any) => void> = new Set()
+  const listeners: Set<StateListener<TState>> = new Set()
 
   const setState: SetState<TState> = (partial, replace) => {
     const nextState = typeof partial === 'function' ? partial(state) : partial
@@ -52,7 +52,7 @@ export default function create<TState extends State>(
 
   const subscribeWithSelector = <StateSlice>(
     listener: StateSliceListener<StateSlice>,
-    selector: StateSelector<TState, StateSlice> = getState,
+    selector: StateSelector<TState, StateSlice> = getState as any,
     equalityFn: EqualityChecker<StateSlice> = Object.is
   ) => {
     let currentSlice: StateSlice = selector(state)
@@ -86,9 +86,9 @@ export default function create<TState extends State>(
         equalityFn
       )
     }
-    listeners.add(listener)
+    listeners.add(listener as StateListener<TState>)
     // Unsubscribe
-    return () => listeners.delete(listener)
+    return () => listeners.delete(listener as StateListener<TState>)
   }
 
   const destroy: Destroy = () => listeners.clear()

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -47,7 +47,7 @@ it('creates a store hook and api object', () => {
 })
 
 it('uses the store with no args', async () => {
-  const useStore = create((set) => ({
+  const useStore = create<any>((set) => ({
     count: 0,
     inc: () => set((state) => ({ count: state.count + 1 })),
   }))
@@ -64,7 +64,7 @@ it('uses the store with no args', async () => {
 })
 
 it('uses the store with selectors', async () => {
-  const useStore = create((set) => ({
+  const useStore = create<any>((set) => ({
     count: 0,
     inc: () => set((state) => ({ count: state.count + 1 })),
   }))
@@ -113,7 +113,7 @@ it('uses the store with a selector and equality checker', async () => {
 })
 
 it('only re-renders if selected state has changed', async () => {
-  const useStore = create((set) => ({
+  const useStore = create<any>((set) => ({
     count: 0,
     inc: () => set((state) => ({ count: state.count + 1 })),
   }))
@@ -148,7 +148,7 @@ it('only re-renders if selected state has changed', async () => {
 })
 
 it('can batch updates', async () => {
-  const useStore = create((set) => ({
+  const useStore = create<any>((set) => ({
     count: 0,
     inc: () => set((state) => ({ count: state.count + 1 })),
   }))
@@ -340,7 +340,7 @@ it('can throw an error in equality checker', async () => {
 })
 
 it('can get the store', () => {
-  const { getState } = create((_, get) => ({
+  const { getState } = create<any>((_, get) => ({
     value: 1,
     getState1: () => get(),
     getState2: () => getState(),
@@ -351,7 +351,7 @@ it('can get the store', () => {
 })
 
 it('can set the store', () => {
-  const { setState, getState } = create((set) => ({
+  const { setState, getState } = create<any>((set) => ({
     value: 1,
     setState1: (v: any) => set(v),
     setState2: (v: any) => setState(v),


### PR DESCRIPTION
Close #95 

This adds a new piece of middleware.
This also avoids `any` (which is a breaking change in types, but not in behavior.)

```ts
import create from "zustand";
import { combine } from "zustand/middleware";

const useStore = create(combine({
  count: 0,
  text: "hello",
}, (set) => ({
  inc: () => set((state) => ({ count: state.count + 1 })),
  setText: (text: string) => set({ text }),
})));
```