### PR TITLE
Readme: Add docs for subscribe equality function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -171,11 +171,14 @@ const paw = useStore.getState().paw
 const unsub1 = useStore.subscribe(console.log)
 // Listening to selected changes, in this case when "paw" changes
 const unsub2 = useStore.subscribe(console.log, state => state.paw)
+// Subscribe also supports an optional equality function
+const unsub3 = useStore.subscribe(console.log, state => [state.paw, state.fur], shallow)
 // Updating state, will trigger listeners
 useStore.setState({ paw: false })
 // Unsubscribe listeners
 unsub1()
 unsub2()
+unsub3()
 // Destroying the store (removing all listeners)
 useStore.destroy()
 


### PR DESCRIPTION
I was wondering if the `subscribe` function also supports an equality function as third parameter. Of course it does! But I had to look it up in the code – so I thought adding it to the readme might be helpful.